### PR TITLE
Use dev.justice.gov.uk for development

### DIFF
--- a/deploy/development/config.yml
+++ b/deploy/development/config.yml
@@ -5,6 +5,6 @@ metadata:
   namespace: justice-gov-uk-dev
 data:
   WP_ENV: "development"
-  WP_HOME: 'https://justice-gov-uk-dev.apps.live.cloud-platform.service.justice.gov.uk'
-  WP_SITEURL: 'https://justice-gov-uk-dev.apps.live.cloud-platform.service.justice.gov.uk/wp'
+  WP_HOME: 'https://dev.justice.gov.uk'
+  WP_SITEURL: 'https://dev.justice.gov.uk/wp'
   SENTRY_DEV_ID: 'development'

--- a/deploy/development/ingress.yml
+++ b/deploy/development/ingress.yml
@@ -26,21 +26,8 @@ spec:
   tls:
   - hosts:
     - justice-gov-uk-dev.apps.live.cloud-platform.service.justice.gov.uk
-  - hosts:
-    - dev.justice.gov.uk
-    secretName: justice-gov-uk-dev-cert-secret
   rules:
   - host: justice-gov-uk-dev.apps.live.cloud-platform.service.justice.gov.uk
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: nginx-service
-            port:
-              number: 8080
-  - host: dev.justice.gov.uk
     http:
       paths:
       - path: /

--- a/deploy/development/ingress.yml
+++ b/deploy/development/ingress.yml
@@ -10,6 +10,9 @@ metadata:
     nginx.ingress.kubernetes.io/auth-secret: basic-auth-secret
     nginx.ingress.kubernetes.io/auth-realm: 'Development User | Authentication Required'
     nginx.ingress.kubernetes.io/server-snippet: |
+      if ($host = 'justice-gov-uk-dev.apps.live.cloud-platform.service.justice.gov.uk') {
+        return 301 https://dev.justice.gov.uk;
+      }
       location = /health {
         auth_basic off;
         access_log off;
@@ -26,8 +29,21 @@ spec:
   tls:
   - hosts:
     - justice-gov-uk-dev.apps.live.cloud-platform.service.justice.gov.uk
+  - hosts:
+    - dev.justice.gov.uk
+    secretName: justice-gov-uk-dev-cert-secret
   rules:
   - host: justice-gov-uk-dev.apps.live.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: nginx-service
+            port:
+              number: 8080
+  - host: dev.justice.gov.uk
     http:
       paths:
       - path: /


### PR DESCRIPTION
Routes the service to dev.justice.gov.uk 