### PR TITLE
Add a container to allow wp-cli over ssh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,8 @@ DB_HOST=mariadb
 DB_USER=mysql
 DB_PASSWORD=mysql
 
+LOCAL_SSH_PASSWORD=ssh-password
+
 SENTRY_DEV_ID=-[user]
 
 # GOV Notify

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,22 @@ COPY deploy/config/local/pool.conf /usr/local/etc/php-fpm.d/pool.conf
 # www-data
 USER 82
 
+
+## target: ssh
+FROM base AS ssh
+
+RUN apk add --no-cache openssh bash
+
+RUN ssh-keygen -A 
+RUN adduser -h /home/ssh-user -s /bin/bash -D ssh-user
+RUN echo 'PasswordAuthentication yes' >> /etc/ssh/sshd_config
+RUN echo -n "ssh-user:test" | chpasswd
+RUN echo 'cd /var/www/html' >> /home/ssh-user/.bash_profile
+
+EXPOSE 22
+
+CMD ["/usr/sbin/sshd", "-D", "-e"]
+
 ###
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,14 +23,17 @@ USER 82
 
 
 ## target: ssh
-FROM base AS ssh
+FROM base AS local-ssh
+
+ARG LOCAL_SSH_PASSWORD
 
 RUN apk add --no-cache openssh bash
 
 RUN ssh-keygen -A 
 RUN adduser -h /home/ssh-user -s /bin/bash -D ssh-user
 RUN echo 'PasswordAuthentication yes' >> /etc/ssh/sshd_config
-RUN echo -n "ssh-user:test" | chpasswd
+RUN echo -n "ssh-user:${LOCAL_SSH_PASSWORD}" | chpasswd
+RUN echo "ssh-user:${LOCAL_SSH_PASSWORD}"
 RUN echo 'cd /var/www/html' >> /home/ssh-user/.bash_profile
 
 EXPOSE 22

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,10 @@ bash:
 bash-nginx:
 	docker compose exec nginx ash
 
+# Starts the application, includes the local-ssh container for migrations.
+migrate:
+	docker compose --profile local-ssh up
+
 # Run tests
 test:
 	composer test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,10 +17,12 @@ services:
         depends_on:
             - mariadb
 
-    php-fpm-ssh:
+    local-ssh:
         build:
             context: .
-            target: ssh
+            target: local-ssh
+            args:
+                LOCAL_SSH_PASSWORD: ${LOCAL_SSH_PASSWORD}
         volumes:
             - .:/var/www/html
         env_file:
@@ -28,7 +30,7 @@ services:
         ports: 
             - 2222:22
         profiles:
-            - ssh
+            - local-ssh
 
     nginx:
         image: nginxinc/nginx-unprivileged:1.25-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,19 @@ services:
         depends_on:
             - mariadb
 
+    php-fpm-ssh:
+        build:
+            context: .
+            target: ssh
+        volumes:
+            - .:/var/www/html
+        env_file:
+            - .env
+        ports: 
+            - 2222:22
+        profiles:
+            - ssh
+
     nginx:
         image: nginxinc/nginx-unprivileged:1.25-alpine
         volumes:


### PR DESCRIPTION
This will allow the migration script (in a different local project) to use wp-cli remotely.

It can be used with the following arguments: `wp --ssh=ssh-user@host.docker.internal:2222/var/www/html db check` and will be useful for `import`ing from an xml file.

It cannot use dory because it's not http traffic. So it exposes the port to the host, and ssh commands for other containers use host.docker.internal

@wilson1000-MoJ do you mind taking a look, please.
- Is it ok to use a hardcoded password if this is only intended to be run locally?
- What's your opinion on me creating a dedicated container for this?
- Could you suggest a good way to add this to the Makefile. Currently I'm doing `docker compose --profile ssh up`.