### PR TITLE
Add serviceAccount + fix dead nginx image ref

### DIFF
--- a/deploy/demo/deployment.tpl
+++ b/deploy/demo/deployment.tpl
@@ -23,19 +23,13 @@ spec:
       volumes:
         - name: uploads
           emptyDir: { }
-        - name: nginx-cache
-          emptyDir: { }
       terminationGracePeriodSeconds: 35
+      serviceAccountName: ${KUBE_NAMESPACE}-service
       containers:
         - name: nginx
-          image: justice-nginx:latest
-          imagePullPolicy: Never
-          resources: { }
+          image: ${ECR_URL}:${IMAGE_TAG_NGINX}
           ports:
             - containerPort: 8080
-          volumeMounts:
-            - name: nginx-cache
-              mountPath: /var/run/nginx-cache
         - name: fpm
           image: ${ECR_URL}:${IMAGE_TAG_FPM}
           ports:

--- a/deploy/development/deployment.tpl
+++ b/deploy/development/deployment.tpl
@@ -23,17 +23,13 @@ spec:
       volumes:
         - name: uploads
           emptyDir: { }
-        - name: nginx-cache
-          emptyDir: { }
       terminationGracePeriodSeconds: 35
+      serviceAccountName: ${KUBE_NAMESPACE}-service
       containers:
       - name: nginx
         image: ${ECR_URL}:${IMAGE_TAG_NGINX}
         ports:
           - containerPort: 8080
-        volumeMounts:
-          - name: nginx-cache
-            mountPath: /var/run/nginx-cache
       - name: fpm
         image: ${ECR_URL}:${IMAGE_TAG_FPM}
         ports:

--- a/deploy/staging/deployment.tpl
+++ b/deploy/staging/deployment.tpl
@@ -23,19 +23,13 @@ spec:
       volumes:
         - name: uploads
           emptyDir: { }
-        - name: nginx-cache
-          emptyDir: { }
       terminationGracePeriodSeconds: 35
+      serviceAccountName: ${KUBE_NAMESPACE}-service
       containers:
         - name: nginx
-          image: justice-nginx:latest
-          imagePullPolicy: Never
-          resources: { }
+          image: ${ECR_URL}:${IMAGE_TAG_NGINX}
           ports:
             - containerPort: 8080
-          volumeMounts:
-            - name: nginx-cache
-              mountPath: /var/run/nginx-cache
         - name: fpm
           image: ${ECR_URL}:${IMAGE_TAG_FPM}
           ports:


### PR DESCRIPTION
Add `serviceAccountName` to deployments to associate IRSA links
Fixed Nginx deployment image referenece