### PR TITLE
Don't use AS3CF_SETTINGS, let's use the GUI during debugging.

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -140,9 +140,13 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
 /**
  * WP Offload Media settings
  */
-if (file_exists(__DIR__ . '/wp-offload-media.php')) {
-    require_once __DIR__ . '/wp-offload-media.php';
-}
+
+// By not setting AS3CF_SETTINGS here, we can use the plugin GUI to configure the settings during debugging.
+// if (file_exists(__DIR__ . '/wp-offload-media.php')) {
+//     require_once __DIR__ . '/wp-offload-media.php';
+// }
+// Only set the 'use-server-role' setting.
+define( 'AS3CF_AWS_USE_EC2_IAM_ROLE', true );
 
 /**
  * Environment-specific settings

--- a/config/application.php
+++ b/config/application.php
@@ -146,7 +146,7 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
 //     require_once __DIR__ . '/wp-offload-media.php';
 // }
 // Only set the 'use-server-role' setting.
-define( 'AS3CF_AWS_USE_EC2_IAM_ROLE', true );
+define('AS3CF_AWS_USE_EC2_IAM_ROLE', true);
 
 /**
  * Environment-specific settings

--- a/config/application.php
+++ b/config/application.php
@@ -146,7 +146,9 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROT
 //     require_once __DIR__ . '/wp-offload-media.php';
 // }
 // Only set the 'use-server-role' setting.
-define('AS3CF_AWS_USE_EC2_IAM_ROLE', true);
+if (!env('AWS_ACCESS_KEY_ID') || !env('AWS_SECRET_ACCESS_KEY')) {
+    define('AS3CF_AWS_USE_EC2_IAM_ROLE', true);
+}
 
 /**
  * Environment-specific settings


### PR DESCRIPTION
I think there may be a couple of settings, that were not set in AS3CF_SETTINGS .e.g.:

- object-ownership-enforced
- block-public-access

For quicker trial and error, let's use the plugin's GUI to trail settings.