### PR TITLE
Log WP_Errors

### DIFF
--- a/public/app/themes/justice/functions.php
+++ b/public/app/themes/justice/functions.php
@@ -16,6 +16,7 @@ if (defined('WP_OFFLOAD_MEDIA_PRESET') && WP_OFFLOAD_MEDIA_PRESET === 'minio') {
 
 require_once 'inc/breadcrumbs.php';
 require_once 'inc/dynamic-menu.php';
+require_once 'inc/errors.php';
 require_once 'inc/layout.php';
 require_once 'inc/mail.php';
 require_once 'src/components/post-meta/post-meta.php';

--- a/public/app/themes/justice/inc/errors.php
+++ b/public/app/themes/justice/inc/errors.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Template name: Error Testing
+ * Template Post Type: page
+ *
+ * Use this file to test error reporting.
+ * It is within WordPress because WordPress modifies error options at runtime.
+ */
+
+if (!defined('ABSPATH') || getenv('WP_ENV') !== 'development') {
+    exit;
+}
+
+/**
+ * wp_error_added
+ * When WP_Error is called, it is up to the developer to access and handle the error, they are not logged by default.
+ * This action/function ensures that any errors added to WP_Error will be logged immediately.
+ */
+
+add_action('wp_error_added', function (string|int $code, string $message, mixed $data, WP_Error $wp_error) {
+    if (is_array($message) || is_object($message)) {
+        error_log("Error code: $code. Message: " . print_r($message, true));
+    } else {
+        error_log("Error code: $code. Message:  $message");
+    }
+}, 10, 4);

--- a/public/app/themes/justice/inc/errors.php
+++ b/public/app/themes/justice/inc/errors.php
@@ -2,6 +2,7 @@
 
 /**
  * Errors
+ * Only allowed in development environment.
  */
 
 if (!defined('ABSPATH') || getenv('WP_ENV') !== 'development') {

--- a/public/app/themes/justice/inc/errors.php
+++ b/public/app/themes/justice/inc/errors.php
@@ -1,11 +1,7 @@
 <?php
 
 /**
- * Template name: Error Testing
- * Template Post Type: page
- *
- * Use this file to test error reporting.
- * It is within WordPress because WordPress modifies error options at runtime.
+ * Errors
  */
 
 if (!defined('ABSPATH') || getenv('WP_ENV') !== 'development') {

--- a/public/app/themes/justice/page_errors.php
+++ b/public/app/themes/justice/page_errors.php
@@ -15,6 +15,6 @@ error_log('Source function: `error_log`. Source file: page_errors.php');
 
 trigger_error('Source function: `trigger_error`. Source file: page_errors.php', E_USER_WARNING);
 
-new WP_Error( 'exception', 'Source function: `new WP_Error`. Source file: page_errors.php' );
+new WP_Error('exception', 'Source function: `new WP_Error`. Source file: page_errors.php');
 
 throw new Exception("Source function: `throw new Exception`. Source file: page_errors.php", 900);

--- a/public/app/themes/justice/page_errors.php
+++ b/public/app/themes/justice/page_errors.php
@@ -13,6 +13,8 @@ if (!defined('ABSPATH') || getenv('WP_ENV') !== 'development') {
 
 error_log('Source function: `error_log`. Source file: page_errors.php');
 
-trigger_error('Source function: `trigger_error. Source file: page_errors.php`', E_USER_WARNING);
+trigger_error('Source function: `trigger_error`. Source file: page_errors.php', E_USER_WARNING);
+
+new WP_Error( 'exception', 'Source function: `new WP_Error`. Source file: page_errors.php' );
 
 throw new Exception("Source function: `throw new Exception`. Source file: page_errors.php", 900);


### PR DESCRIPTION
When WP_Error is called, it is up to the developer to access and handle the error, they are not logged by default.

This action/function ensures that any errors added to WP_Error will be logged immediately.