### PR TITLE
fix for missing asset.php file

### DIFF
--- a/public/app/themes/justice/inc/simple-guten-fields/simple-guten-fields.php
+++ b/public/app/themes/justice/inc/simple-guten-fields/simple-guten-fields.php
@@ -27,7 +27,7 @@ class SimpleGutenFields
     {
         $dir = __DIR__;
 
-        $script_asset_path = "$dir/../../dist/block-editor.asset.php";
+        $script_asset_path = "$dir/../../dist/php/block-editor.asset.php";
         if (! file_exists($script_asset_path)) {
             throw new \Error(
                 'You need to run `npm start` or `npm run build` for the "create-block/simple-guten-fields" block first.'

--- a/public/app/themes/justice/webpack.mix.js
+++ b/public/app/themes/justice/webpack.mix.js
@@ -13,6 +13,7 @@ mix
     .css('src/css/media.queries.css', 'dist/css/')
     .css('src/css/editor-style.css', 'dist/css/')
     .css('src/css/wp-admin-override.css', 'dist/css/')
+    .copy('dist/*.asset.php', 'dist/php')
     .options({ processCssUrls: false })
 
 if (mix.inProduction()) {


### PR DESCRIPTION
- webpack to copy asset.php files to `dist/php`
- update the path in php application
- Dockerfile
    - Move `assets-build` above `build-fpm`
    - minimise files copied over to `assets-build` from the codebase
    - build-fpm to get `dist/php` from `assets-build`