### PR TITLE
Documents post type and customisation for our application.

### DIFF
--- a/config/wp-offload-media.php
+++ b/config/wp-offload-media.php
@@ -47,7 +47,7 @@ $as3_settings = array(
     // Serve files over HTTPS
     'force-https' => !!env('CLOUDFRONT_URL'),
     // Remove the local file version once offloaded to bucket
-    'remove-local-file' => false,
+    'remove-local-file' => true,
     // Access Control List for the bucket
     'use-bucket-acls' => false,
 );

--- a/deploy/config/local/php-fpm.conf
+++ b/deploy/config/local/php-fpm.conf
@@ -7,5 +7,6 @@ include server_name.conf;
 include fastcgi_params;
 fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 fastcgi_param SCRIPT_NAME $fastcgi_script_name;
-# Increase limits to allow for large file uploads. i.e. content import via Importer Plugin.
-fastcgi_param PHP_VALUE "upload_max_filesize=32M \n post_max_size=32M \n max_execution_time=300";
+# Increase limits to allow for large file uploads. 
+# i.e. content import via Importer Plugin. & .zip files via wp-document-revisions
+fastcgi_param PHP_VALUE "upload_max_filesize=200M \n post_max_size=200M \n max_execution_time=300";

--- a/deploy/config/php-fpm.conf
+++ b/deploy/config/php-fpm.conf
@@ -22,7 +22,7 @@ include fastcgi_params;
 fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 fastcgi_param SCRIPT_NAME $fastcgi_script_name;
 # Increase limits to allow for large file uploads. i.e. content import via Importer Plugin.
-fastcgi_param PHP_VALUE "upload_max_filesize=64M \n post_max_size=64M \n max_execution_time=300";
+fastcgi_param PHP_VALUE "upload_max_filesize=200M \n post_max_size=200M \n max_execution_time=300";
 
 # configure buffers
 fastcgi_buffers 16 64k;

--- a/public/app/themes/justice/functions.php
+++ b/public/app/themes/justice/functions.php
@@ -18,6 +18,7 @@ if (Config::get('WP_OFFLOAD_MEDIA_PRESET') === 'minio') {
 require_once 'inc/block-editor.php';
 require_once 'inc/breadcrumbs.php';
 require_once 'inc/debug.php';
+require_once 'inc/documents.php';
 require_once 'inc/disable-comments.php';
 require_once 'inc/dynamic-menu.php';
 require_once 'inc/errors.php';
@@ -33,6 +34,7 @@ if (getenv('WP_ENV') === 'development') {
 }
 
 new Justice\Comments();
+new Justice\Documents();
 new Justice\Layout();
 new Justice\SimpleGutenFields();
 

--- a/public/app/themes/justice/inc/disable-comments.php
+++ b/public/app/themes/justice/inc/disable-comments.php
@@ -49,6 +49,9 @@ class Comments
 
         // Hide existing comments.
         add_filter('comments_array', '__return_empty_array', 10, 2);
+
+        // Set default state on posts.
+        add_filter('get_default_comment_status', fn() => 'closed');
     }
 
     /** Disable support for comments and trackbacks in post types. */

--- a/public/app/themes/justice/inc/documents.php
+++ b/public/app/themes/justice/inc/documents.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace MOJ\Justice;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Documents
+ * Actions and filters related to WordPress documents post type.
+ */
+
+class Documents
+{
+
+    public function __construct()
+    {
+        $this->addHooks();
+        $this->removeHooks();
+    }
+
+    public function addHooks()
+    {
+        add_action('admin_init', [$this, 'hideEditor']);
+    }
+
+    /**
+     * Remove the editor for the document post type.
+     */
+
+    public function hideEditor()
+    {
+        remove_post_type_support('document', 'editor');
+    }
+
+    /**
+     * Remove the title: Document Description
+     */
+
+    public function removeHooks()
+    {
+        global $wpdr;
+        if (!isset($wpdr)) {
+            return;
+        }
+        remove_action('edit_form_after_title', [$wpdr->admin, 'prepare_editor']);
+    }
+}

--- a/public/app/themes/justice/inc/documents.php
+++ b/public/app/themes/justice/inc/documents.php
@@ -146,13 +146,20 @@ class Documents
 
         // If filename is hex & 32 chars long, then set a ContentDisposition filename.
         if (preg_match('/^[a-f0-9]{32}$/', $pathinfo['filename'])) {
+            // Get the basename from the request.
+            $content_disposition_basename = sanitize_file_name($_REQUEST['name']);
+
             // Get the document ID, permalink and filename.
             $document_id = wp_get_post_parent_id($attach_id);
             $document_permalink = get_permalink($document_id);
-            $document_filename = pathinfo($document_permalink, PATHINFO_FILENAME);
 
-            // Build a basename from the document filename with the file extension.
-            $content_disposition_basename = $document_filename . '.' . $pathinfo['extension'];
+            // If the permalink is set then use that as the filename.
+            if (!str_contains($document_permalink, '?post_type=document&p=')) {
+                $document_filename = pathinfo($document_permalink, PATHINFO_FILENAME);
+                // Build a basename from the document permalink filename with the file extension.
+                $content_disposition_basename = $document_filename . '.' . $pathinfo['extension'];
+            }
+
             // Write a filename to S3 metadata. This is what the downloaded file will be called.
             $args['ContentDisposition'] .= ';filename="' . $content_disposition_basename . '"';
         }

--- a/public/app/themes/justice/inc/documents.php
+++ b/public/app/themes/justice/inc/documents.php
@@ -14,6 +14,15 @@ if (!defined('ABSPATH')) {
 class Documents
 {
 
+    // File extensions to mark as downloadable in S3.
+    private $content_disposition_extensions = [
+        'doc', 'docx', 'pdf', 'zip', 'xls', 'xlsx'
+    ];
+
+    // Max filesize for wp-document-revisions to stream via php.
+    // 10000000 = 10MB.
+    private $php_stream_max_filesize = 20000000;
+
     public function __construct()
     {
         $this->addHooks();
@@ -23,6 +32,9 @@ class Documents
     public function addHooks()
     {
         add_action('admin_init', [$this, 'hideEditor']);
+        add_filter('document_serve_use_gzip', [$this, 'filterGzip'], null, 3);
+        add_filter('document_serve', [$this, 'maybeRedirectToCdn'], null, 3);
+        add_filter('as3cf_object_meta', [$this,  'addObjectMeta'], 10, 4);
     }
 
     /**
@@ -46,4 +58,105 @@ class Documents
         }
         remove_action('edit_form_after_title', [$wpdr->admin, 'prepare_editor']);
     }
+
+    /**
+     * isDocumentAttachment
+     * Check if the attachment is attached to a document post.
+     */
+
+    public function isDocumentAttachment($attach_id): bool
+    {
+        $post_parent = wp_get_post_parent_id($attach_id);
+        $parent_post_type = get_post_type($post_parent);
+
+        return $parent_post_type && $parent_post_type === 'document' ? true : false;
+    }
+
+    /**
+     * filterGzip
+     * Should the file be gzipped? Don't gzip zip files.
+     */
+
+    public function filterGzip($gzip, $mimetype, $filesize)
+    {
+
+        if ('application/zip' === $mimetype) {
+            return false;
+        }
+
+        return $gzip;
+    }
+
+    /**
+     * maybeRedirectToCdn
+     * Stream the file via php, or redirect the user to the CDN.
+     */
+
+    function maybeRedirectToCdn($file, $post_id, $attach_id)
+    {
+
+        // Only redirect published files to the CDN.
+        if (get_post_status($post_id) !== 'publish') {
+            return $file;
+        }
+
+        // Get the filesize. 
+        $file_size = filesize(get_attached_file($attach_id));
+
+        // If it's too big then redirect to the CDN.
+        if ($file_size > $this->php_stream_max_filesize) {
+            // Be aware that this url will still work even if the document visibility is later changed to private.
+            // This should not be a problem with justice.gov.uk as the document visibility is always public.
+            // It it becomes an issue, let's sign the URLs with a short expiry time.
+            $url = wp_get_attachment_url($attach_id);
+            wp_redirect($url);
+            exit;
+        }
+
+        return $file;
+    }
+
+    /**
+     * addObjectMeta
+     * Add object meta to the S3 object.
+     * This function is called whenever any file is upladed to S3.
+     * Vai the Media Library or the Document post type.
+     */
+
+    public function addObjectMeta($args, $attach_id)
+    {
+
+        // Return if we're not dealing with a document attachment.
+        if (!$this->isDocumentAttachment($attach_id)) {
+            return $args;
+        }
+
+        // Get info based on the attachment URL.
+        $pathinfo = pathinfo($args['Key']);
+
+        // Return if we don't need to mark the url as a download, based on file extension.
+        if (!in_array($pathinfo['extension'], $this->content_disposition_extensions)) {
+            return $args;
+        }
+
+        // Mark as downloadable download.
+        $args['ContentDisposition'] = 'attachment';
+
+        // If filename is hex & 32 chars long, then set $content_disposition_filename.
+        if (preg_match('/^[a-f0-9]{32}$/', $pathinfo['filename'])) {
+
+            // Get the document ID, permalink and filename.
+            $document_id = wp_get_post_parent_id($attach_id);
+            $document_permalink = get_permalink($document_id);
+            $document_filename = pathinfo($document_permalink, PATHINFO_FILENAME);
+
+            // Build a basename from the document filename with the file extension.
+            $content_disposition_basename = $document_filename . '.' . $pathinfo['extension'];
+            // Write a filename to S3 metadata. This is what the downloaded file will be called.
+            $args['ContentDisposition'] .= ';filename="' . $content_disposition_basename . '"';
+        }
+
+        return $args;
+    }
+
 }

--- a/public/app/themes/justice/inc/documents.php
+++ b/public/app/themes/justice/inc/documents.php
@@ -142,7 +142,7 @@ class Documents
         // Mark as downloadable download.
         $args['ContentDisposition'] = 'attachment';
 
-        // If filename is hex & 32 chars long, then set $content_disposition_filename.
+        // If filename is hex & 32 chars long, then set a ContentDisposition filename.
         if (preg_match('/^[a-f0-9]{32}$/', $pathinfo['filename'])) {
 
             // Get the document ID, permalink and filename.

--- a/public/app/themes/justice/inc/documents.php
+++ b/public/app/themes/justice/inc/documents.php
@@ -33,7 +33,7 @@ class Documents
     {
         add_action('admin_init', [$this, 'hideEditor']);
         add_filter('document_serve_use_gzip', [$this, 'filterGzip'], null, 3);
-        add_filter('document_serve', [$this, 'maybeRedirectToCdn'], null, 3);
+        add_filter('document_serve', [$this, 'maybeRedirectToAttachmentUrl'], null, 3);
         add_filter('as3cf_object_meta', [$this,  'addObjectMeta'], 10, 4);
     }
 
@@ -88,11 +88,11 @@ class Documents
     }
 
     /**
-     * maybeRedirectToCdn
-     * Stream the file via php, or redirect the user to the CDN.
+     * maybeRedirectToAttachmentUrl
+     * Stream the file via php, or redirect the user to the attachment URL (could be S3, CDN etc.).
      */
 
-    function maybeRedirectToCdn($file, $post_id, $attach_id)
+    function maybeRedirectToAttachmentUrl($file, $post_id, $attach_id)
     {
 
         // Only redirect published files to the CDN.

--- a/public/app/themes/justice/inc/documents.php
+++ b/public/app/themes/justice/inc/documents.php
@@ -16,12 +16,11 @@ class Documents
 
     // File extensions to mark as downloadable in S3.
     private $content_disposition_extensions = [
-        'doc', 'docx', 'pdf', 'zip', 'xls', 'xlsx'
+        'doc', 'docx', 'pdf', 'xls', 'xlsx', 'zip'
     ];
 
-    // Max filesize for wp-document-revisions to stream via php.
-    // 10000000 = 10MB.
-    private $php_stream_max_filesize = 20000000;
+    // Max filesize for wp-document-revisions to stream via php. 15000000 = 15MB.
+    private $php_stream_max_filesize = 15000000;
 
     public function __construct()
     {
@@ -92,7 +91,7 @@ class Documents
      * Stream the file via php, or redirect the user to the attachment URL (could be S3, CDN etc.).
      */
 
-    function maybeRedirectToAttachmentUrl($file, $post_id, $attach_id)
+    public function maybeRedirectToAttachmentUrl($file, $post_id, $attach_id)
     {
 
         // Only redirect published files to the CDN.
@@ -100,7 +99,7 @@ class Documents
             return $file;
         }
 
-        // Get the filesize. 
+        // Get the filesize.
         $file_size = filesize(get_attached_file($attach_id));
 
         // If it's too big then redirect to the CDN.
@@ -144,7 +143,6 @@ class Documents
 
         // If filename is hex & 32 chars long, then set a ContentDisposition filename.
         if (preg_match('/^[a-f0-9]{32}$/', $pathinfo['filename'])) {
-
             // Get the document ID, permalink and filename.
             $document_id = wp_get_post_parent_id($attach_id);
             $document_permalink = get_permalink($document_id);
@@ -158,5 +156,4 @@ class Documents
 
         return $args;
     }
-
 }


### PR DESCRIPTION
- Now that S3 upload is working, it's safe to set 'remove-local-file' => true in the plugin's settings.
- Increase upload file limits for local and prod. This is because the existing file sizes are up to 150M.
- Implement an application level limit of 64MB on non-document uploads.
- Set comment_status to false by default.
- Turn off gzip compression for zip files.
- Redirect the user download the file directly from the CDN for large public documents only. 
   - I was seeing out of memory errors during testing. 
   - The default behaviour for wp-document-revisions is to stream the files through the php application. 
   - This is great for security, but a waste of resources if the file can just be served via the CDN.
   - The current code will redirect document urls (temporary 302) to the CDN.
   - For specific file types, they are marked with metadate in S3, `ContentDisposition` indicates that the browser should download it.
   - `filename` is also set on the metadata, to prevent the CDN served files having the md5 hash as the filename.