### PR TITLE
Fix typo in wp-document-revsions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,10 +59,11 @@ ARG COMPOSER_PASS
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
-COPY ./bin/composer-auth.sh composer-auth.sh
+COPY ./bin/composer-auth.sh ./bin/composer-post-install.sh ./bin/
 
-RUN chmod +x composer-auth.sh && \
-    ./composer-auth.sh
+RUN chmod +x ./bin/composer-auth.sh && \
+    ./bin/composer-auth.sh
+RUN chmod +x ./bin/composer-post-install.sh
 
 # non-root
 USER 82

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ node-assets:
 	npm run watch
 
 composer-assets:
+	@chmod +x ./bin/composer-post-install.sh
 	@chmod +x ./bin/local-composer-assets.sh
 	@docker compose exec php-fpm ./bin/local-composer-assets.sh ash
 

--- a/bin/composer-post-install.sh
+++ b/bin/composer-post-install.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env ash
+
+# Fix a typo in the wp-document-revisions plugin.
+
+# Define the search and replace strings.
+WPDR_FILE=public/app/plugins/wp-document-revisions/includes/class-wp-document-revisions.php
+WPDR_SEARCH=subdtr
+WPDR_REPLACE=subdir
+
+# If serach string is in file. Then replace it.
+if grep -q  $WPDR_SEARCH $WPDR_FILE ; then
+  echo "Fixing typo in wp-document-revisions..."
+  sed -i "s/$WPDR_SEARCH/$WPDR_REPLACE/g" $WPDR_FILE
+fi

--- a/bin/composer-post-install.sh
+++ b/bin/composer-post-install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env ash
+#!/usr/bin/env sh
 
 # Fix a typo in the wp-document-revisions plugin.
 

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "wpackagist-plugin/simple-301-redirects": "^2.0",
         "wpackagist-plugin/simple-definition-list-blocks": "6.0.1",
         "wpackagist-plugin/wordpress-importer": "~0.8.2",
-        "wpackagist-plugin/wp-document-revisions": "^3.5.0"
+        "wpackagist-plugin/wp-document-revisions": "^3.6.0"
     },
     "require-dev": {
         "10up/wp_mock": "^1.0.1",
@@ -118,10 +118,18 @@
                 "The code has been reviewed by Davey Brown and it doesn't introduce any security issues.",
                 "The attack surface has been further reduced by disabling the plugin programmatically and",
                 "loading it's js within the theme."
+            ],
+            "wpackagist-plugin/wp-document-revisions": [
+                "Version 3.6.0 of this plugin has a typo in file class-wp-document-revisions.php",
+                "The post-package-install script replaces the typo subdtr with the correct spelling subdir",
+                "This is a temporary fix until the plugin is updated upstream."
             ]
         }
     },
     "scripts": {
+        "post-package-install": [
+            "sed -i 's/subdtr/subdir/g' public/app/plugins/wp-document-revisions/includes/class-wp-document-revisions.php"
+        ],
         "test": [
             "phpcs --report=summary"
         ],

--- a/composer.json
+++ b/composer.json
@@ -121,14 +121,18 @@
             ],
             "wpackagist-plugin/wp-document-revisions": [
                 "Version 3.6.0 of this plugin has a typo in file class-wp-document-revisions.php",
-                "The post-package-install script replaces the typo subdtr with the correct spelling subdir",
-                "This is a temporary fix until the plugin is updated upstream."
+                "The composer-post-install script replaces the typo subdtr with the correct spelling subdir",
+                "This is a temporary fix until the plugin is updated upstream.",
+                "https://github.com/wp-document-revisions/wp-document-revisions/pull/346"
             ]
         }
     },
     "scripts": {
-        "post-package-install": [
-            "sed -i 's/subdtr/subdir/g' public/app/plugins/wp-document-revisions/includes/class-wp-document-revisions.php"
+        "post-install-cmd": [
+            "bin/composer-post-install.sh"
+        ],
+        "post-update-cmd": [
+            "bin/composer-post-install.sh"
         ],
         "test": [
             "phpcs --report=summary"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2c65e7b92b4ef1d9994cc39f936599d5",
+    "content-hash": "96f92fe0e35a274e5da2025bbd83901f",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "96f92fe0e35a274e5da2025bbd83901f",
+    "content-hash": "23e31f96606bdee80faa93c8fab53015",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "efeb6e1e72876d0f8d0613e1ad085156",
+    "content-hash": "2c65e7b92b4ef1d9994cc39f936599d5",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -6968,15 +6968,15 @@
         },
         {
             "name": "wpackagist-plugin/wp-document-revisions",
-            "version": "3.5.0",
+            "version": "3.6.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wp-document-revisions/",
-                "reference": "tags/3.5.0"
+                "reference": "tags/3.6.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wp-document-revisions.3.5.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/wp-document-revisions.3.6.0.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"


### PR DESCRIPTION
This causes documents to not upload.

Works locally. Once it's verified working locally it can be applied to intranet too.