### PR TITLE
CDPT-1076 Add theme support for title-tag.

### DIFF
--- a/public/app/themes/justice/functions.php
+++ b/public/app/themes/justice/functions.php
@@ -33,6 +33,7 @@ require_once 'inc/simple-definition-list-blocks.php';
 require_once 'inc/simple-guten-fields/simple-guten-fields.php';
 require_once 'inc/taxonomies.php';
 require_once 'inc/theme-assets.php';
+require_once 'inc/theme.php';
 require_once 'inc/utils.php';
 
 if (getenv('WP_ENV') === 'development') {
@@ -52,6 +53,7 @@ new Justice\Search();
 new Justice\SimpleGutenFields();
 new Justice\SimpleDefinitionsListBlocks();
 new Justice\ThemeAssets();
+new Justice\Theme();
 
 $block_editor = new Justice\BlockEditor();
 $block_editor->addHooks();

--- a/public/app/themes/justice/header.php
+++ b/public/app/themes/justice/header.php
@@ -11,7 +11,6 @@
 <head>
     <meta charset="<?php bloginfo('charset'); ?>"/>
     <meta name="viewport" content="width=device-width"/>
-    <title><?php wp_title('|', true, 'right'); ?></title>
     <link rel="profile" href="https://gmpg.org/xfn/11"/>
     <link rel="pingback" href="<?php echo esc_url(get_bloginfo('pingback_url')); ?>">
     <?php // Loads HTML5 JavaScript file to add support for HTML5 elements in older IE versions. ?>

--- a/public/app/themes/justice/inc/post-meta/post-meta.php
+++ b/public/app/themes/justice/inc/post-meta/post-meta.php
@@ -117,14 +117,14 @@ class PostMeta
      * Otherwise, return the default title.
      *
      * @param array $title_parts
-     * @return array 
+     * @return array
      */
 
     public function titleFilter(array $title_parts): array
     {
         $title_tag = $this->getMeta('_title_tag', get_the_ID());
 
-        if(!empty($title_tag)) {
+        if (!empty($title_tag)) {
             $title_parts['title'] = trim($title_tag);
             unset($title_parts['tagline']);
             unset($title_parts['site']);

--- a/public/app/themes/justice/inc/post-meta/post-meta.php
+++ b/public/app/themes/justice/inc/post-meta/post-meta.php
@@ -37,7 +37,7 @@ class PostMeta
         add_filter('sgf_register_fields', [$post_meta_constants, 'navigationFields'], 5);
         add_filter('sgf_register_fields', [$post_meta_constants, 'metaFields'], 5);
         add_filter('sgf_register_fields', [$post_meta_constants, 'panelFields'], 5);
-        add_filter('wp_title', [$this, 'titleFilter'], 10, 2);
+        add_filter('document_title_parts', [$this, 'titleFilter'], 10, 2);
     }
 
     /**
@@ -114,18 +114,22 @@ class PostMeta
      * Filter the title.
      *
      * If metadata is set for the title tag, return that.
-     * Otherwise, trim spaces and the separator from the start and end of the default title.
+     * Otherwise, return the default title.
      *
-     * @param string $title
-     * @param string $sep
-     * @return string
+     * @param array $title_parts
+     * @return array 
      */
 
-    public function titleFilter(string $title, string $sep): string
+    public function titleFilter(array $title_parts): array
     {
-
         $title_tag = $this->getMeta('_title_tag', get_the_ID());
 
-        return empty($title_tag) ? trim($title, " " . $sep) : esc_html(trim($title_tag));
+        if(!empty($title_tag)) {
+            $title_parts['title'] = trim($title_tag);
+            unset($title_parts['tagline']);
+            unset($title_parts['site']);
+        }
+
+        return $title_parts;
     }
 }

--- a/public/app/themes/justice/inc/post-meta/post-meta.php
+++ b/public/app/themes/justice/inc/post-meta/post-meta.php
@@ -37,7 +37,7 @@ class PostMeta
         add_filter('sgf_register_fields', [$post_meta_constants, 'navigationFields'], 5);
         add_filter('sgf_register_fields', [$post_meta_constants, 'metaFields'], 5);
         add_filter('sgf_register_fields', [$post_meta_constants, 'panelFields'], 5);
-        add_filter('document_title_parts', [$this, 'titleFilter'], 10, 2);
+        add_filter('document_title_parts', [$this, 'titleFilter']);
     }
 
     /**

--- a/public/app/themes/justice/inc/theme.php
+++ b/public/app/themes/justice/inc/theme.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace MOJ\Justice;
+
+defined('ABSPATH') || exit;
+
+/**
+ * A php class related to theme support.
+ */
+
+class Theme
+{
+
+    public function __construct()
+    {
+        $this->addHooks();
+    }
+
+    public function addHooks(): void
+    {
+        add_action('after_setup_theme', [$this, 'addThemeSupport']);
+    }
+
+    /**
+     * Add theme support for title-tag.
+     *
+     * @see https://developer.wordpress.org/reference/functions/add_theme_support/
+     *
+     * @return void
+     */
+
+    public function addThemeSupport(): void
+    {
+        add_theme_support('title-tag');
+    }
+}


### PR DESCRIPTION
The current theme had issues setting the `<title>` element on the homepage.

Adding theme support for `title-tag` is the recommended approach for fixing the issue. 

Reference:

- https://developer.wordpress.org/reference/functions/add_theme_support/
- https://stackoverflow.com/a/37223205/6671505
- https://wordpress.stackexchange.com/questions/305353/cant-change-the-title-tag-with-wp-title-filter
