### PR TITLE
Handle requests to the application host, by sending them to a loopback url.

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -61,6 +61,7 @@ if (!env('WP_ENVIRONMENT_TYPE') && in_array(WP_ENV, ['production', 'staging', 'd
  */
 Config::define('WP_HOME', env('WP_HOME'));
 Config::define('WP_SITEURL', env('WP_SITEURL'));
+Config::define('WP_LOOPBACK', env('WP_LOOPBACK') ?: 'http://localhost:8080');
 
 /**
  * Custom Content Directory

--- a/deploy/config/local/server.conf
+++ b/deploy/config/local/server.conf
@@ -15,7 +15,6 @@ upstream php {
 
 server {
     listen  8080 default_server; # For default requests.
-    listen  80;                  # For localhost loopback only.
     server_name localhost;
 
     root /var/www/html/public;

--- a/deploy/demo/config.yml
+++ b/deploy/demo/config.yml
@@ -7,4 +7,5 @@ data:
   WP_ENV: "production"
   WP_HOME: 'https://demo.justice.gov.uk'
   WP_SITEURL: 'https://demo.justice.gov.uk/wp'
+  WP_LOOPBACK: 'http://localhost:8080'
   SENTRY_DEV_ID: '-demo'

--- a/deploy/development/config.yml
+++ b/deploy/development/config.yml
@@ -7,3 +7,4 @@ data:
   WP_ENV: "development"
   WP_HOME: 'https://dev.justice.gov.uk'
   WP_SITEURL: 'https://dev.justice.gov.uk/wp'
+  WP_LOOPBACK: 'http://localhost:8080'

--- a/deploy/staging/config.yml
+++ b/deploy/staging/config.yml
@@ -7,3 +7,4 @@ data:
   WP_ENV: "staging"
   WP_HOME: 'https://stage.justice.gov.uk'
   WP_SITEURL: 'https://stage.justice.gov.uk/wp'
+  WP_LOOPBACK: 'http://localhost:8080'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,6 @@ services:
         depends_on:
             - mariadb
             - minio
-        links:
-          - "nginx:${SERVER_NAME}"
 
     nginx:
       build:
@@ -39,6 +37,7 @@ services:
         - "8080:8080"
       depends_on:
         - node
+        - php-fpm
 
     node:
         image: node:20


### PR DESCRIPTION
This PR sets a config of `WP_LOOPBACK` to one that is defined in the environment variables.

If there's a WP request to `home_url` then this is replaced with `WP_LOOPBACK`. 

As `WP_LOOPBACK` can be the nginx container, we don't need ssl, or basic auth.

Some un-needed local config has also been removed/reverted.

