### PR TITLE
Version bump ccfw assets - clear old js from browser's cache.

### DIFF
--- a/public/app/themes/justice/inc/plugin-hacks.php
+++ b/public/app/themes/justice/inc/plugin-hacks.php
@@ -8,7 +8,7 @@ add_action('wp_enqueue_scripts', function () {
         'ccfw-script-frontend',
         get_template_directory_uri() . '/dist/patch/js/ccfw-frontend.js',
         ['jquery'],
-        1.1,
+        1.2,
         true
     );
 
@@ -16,7 +16,7 @@ add_action('wp_enqueue_scripts', function () {
         'ccfw-script',
         get_template_directory_uri() . '/dist/patch/js/ccfw-cookie-manage.js',
         ['jquery'],
-        1.1,
+        1.2,
         true
     );
 });


### PR DESCRIPTION
Fixes: https://ministryofjustice.sentry.io/issues/5453583632/?environment=production&project=4506813195157504&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=1