### PR TITLE
Disable CONCATENATE_SCRIPTS, COMPRESS_CSS & COMPRESS_SCRIPTS

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -116,6 +116,14 @@ Config::define('DISALLOW_FILE_EDIT', true);
 // Disable plugin and theme updates and installation from the admin
 Config::define('DISALLOW_FILE_MODS', true);
 
+// Disable php script concatenation at runtime - we serve WP assets via nginx
+Config::define('CONCATENATE_SCRIPTS', false);
+
+// For completeness, disable css and script compression at runtime
+// These should be irrelevant because CONCATENATE_SCRIPTS is false
+Config::define('COMPRESS_CSS', false);
+Config::define('COMPRESS_SCRIPTS', false);
+
 // Limit the number of post revisions
 Config::define('WP_POST_REVISIONS', env('WP_POST_REVISIONS') ?? true);
 

--- a/deploy/config/local/server.conf
+++ b/deploy/config/local/server.conf
@@ -111,6 +111,13 @@ server {
         deny all;
     }
 
+    # Deny access to load-scripts.php and load-styles.php to prevent DoS attacks.
+    # These are endpoints used by php to concatenate scripts and styles.
+    # We're serving these with nginx instead.
+    location ~* ^/wp/wp-admin/load-(?:scripts|styles)\.php$ {
+        deny all;
+    }
+
     # WordPress admin rate limit
     location = /wp/wp-login.php {
         limit_req zone=flood burst=5 nodelay;


### PR DESCRIPTION
The endpoints: load-scripts.php and load-styles.php are used by WP to concatenate and compress assets at runtime.
Since we are using nginx, these assets can be served via nginx instead.

This PR makes the following changes:

- Disable the env vars: CONCATENATE_SCRIPTS, COMPRESS_CSS & COMPRESS_SCRIPTS
- Block the endpoints: load-scripts.php and load-styles.php - this change means they are not used but are DoS vectors.

This code is difficult to test locally because `Config::define('SCRIPT_DEBUG', true);` in `config/environments/development.php` means that scripts are not concatenated. Temporarily disable this and access an admin page locally to see `CONCATENATE_SCRIPTS` in action.

This should have the effect of fixing the intermittent CPU spikes. If not, it is still good practice :)

Further reading:

- https://wordpress.org/support/topic/high-cpu-on-wp-admin-load-styles-php/
- https://discourse.roots.io/t/upstream-timed-out-for-load-styles-php/26973/4
- https://mojdt.slack.com/archives/C03QE40GVA6/p1717692235182989