### PR TITLE
Feature/cdpt 1704 - Amends - UI for inline anchor links

### DIFF
--- a/public/app/themes/justice/src/components/core-rich-text/anchor.js
+++ b/public/app/themes/justice/src/components/core-rich-text/anchor.js
@@ -39,6 +39,11 @@ const settings = {
   interactive: false,
   tagName: "a",
   title: __("Anchor", "block-options"),
+  // @ts-ignore - this is valid according rich-text.js.
+  attributes: {
+    id:  "id",
+    name:  "name",
+  },
 };
 
 /**
@@ -264,11 +269,14 @@ const Edit = ({ contentRef, isActive, value, onChange }) => {
    */
 
   const applyAttributes = (newId) => {
-    const cleanId = cleanForSlug(newId);
+    // Utilise JS's decodeURI & encodeURI functions to ensure the newId is a valid url fragment.
+    const dummyUrl = "http://a.com/#";
+    const validUrl = encodeURI(decodeURI(`${dummyUrl}${newId}`));
+    const validId = validUrl.replace(dummyUrl, "");
 
-    if (cleanId !== newId) {
+    if (validId !== newId) {
       alert(
-        `Anchor name "${newId}" is not a valid anchor name. It will be changed to "${cleanId}".`,
+        `Anchor name "${newId}" is not a valid anchor name. It will be changed to "${validId}".`,
       );
     }
 
@@ -276,7 +284,7 @@ const Edit = ({ contentRef, isActive, value, onChange }) => {
       applyFormat(value, {
         type: settings.name,
         // @ts-ignore - due to WP's lack of types/docs.
-        attributes: { id: cleanId, name: cleanId },
+        attributes: { id: validId, name: validId },
       }),
     );
   };

--- a/public/app/themes/justice/src/sass/justice-theme.scss
+++ b/public/app/themes/justice/src/sass/justice-theme.scss
@@ -341,7 +341,7 @@ ul#adminmenu > li.current > a.current:after {
 Gutenberg/WordPress logo override
  */
 body.is-fullscreen-mode {
-  .edit-post-header a,
+  .edit-post-header a.edit-post-fullscreen-mode-close,
   .edit-site-navigation-toggle button {
     &.components-button {
       > svg, > img {


### PR DESCRIPTION
- Amend validation to allow existing ids , and use named attributes
- Block editor page css fix. Open page button hidden was hidden, white space to the left of the update button. (@wilson1000 - a minor fix that I've bundled in here by increasing the specificty).

<img width="460" alt="image" src="https://github.com/ministryofjustice/justice-gov-uk/assets/15802017/43710751-73ae-41d5-92cf-4476fb20020b">
