### PR TITLE
Feature/cdpt 1534 use nginx for redirects amends

### DIFF
--- a/deploy/config/local/server.conf
+++ b/deploy/config/local/server.conf
@@ -25,6 +25,9 @@ server {
     root /var/www/html/public;
     index index.php index.html;
 
+    # Prevents internal rewrites/redirects going to http and port 8080.
+    absolute_redirect off;
+
     client_max_body_size 250m;
 
     location = /favicon.ico {

--- a/deploy/config/server.conf
+++ b/deploy/config/server.conf
@@ -24,6 +24,7 @@ server {
     root /var/www/html/public;
     index index.php;
 
+    # Prevents internal rewrites going to http and port 8080.
     absolute_redirect off;
 
     location = /favicon.ico {

--- a/deploy/config/server.conf
+++ b/deploy/config/server.conf
@@ -24,6 +24,8 @@ server {
     root /var/www/html/public;
     index index.php;
 
+    absolute_redirect off;
+
     location = /favicon.ico {
         log_not_found off;
         access_log off;


### PR DESCRIPTION
nginx is running in the context that incoming requests are http and port 8080.

This can be seen by a bug that I've identified e.g. on stage https://stage.justice.gov.uk/wp-content/uploads/test will redirect to http://stage.justice.gov.uk:8080/app/uploads/test , then https://stage.justice.gov.uk:8080/app/uploads/test

This fix will use relative paths for redirects, avoiding the above issue.

See: https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.2