### PR TITLE
Accessibility improvements and link updates

### DIFF
--- a/public/app/frontend/src/components/footer/footer.html.twig
+++ b/public/app/frontend/src/components/footer/footer.html.twig
@@ -7,6 +7,7 @@ Available variables:
         - url: string The url for the link
         - label: string The label for the link
         - newTab: boolean Will this link open in a new tab?
+        - newTabVisuallyHidden: boolean Will the (open in a new tab) text be shown to all users or screen readers only?
 example:
     {% include '@components/footer/footer.html.twig' with {
         links: [
@@ -29,6 +30,7 @@ example:
                 <li class="footer__link">
                     {% include '@components/link/link.html.twig' with {
                         newTab: link.newTab,
+                        newTabVisuallyHidden: link.newTabVisuallyHidden,
                         url: link.url,
                         label: link.label
                     } %}
@@ -38,14 +40,12 @@ example:
         <div class="footer__details">
             <p class="footer__heading">Citizen and business advice</p>
             <div class="footer__content-wrapper">
-                <a class="footer__gov" href="/">
-                <span class="footer__gov-label visually-hidden">
-                    Go to Gov UK (opens in a new tab)
-                </span>
+            {# Hide logo link from screen readers as it's repeated in the text link #}
+                <a class="footer__gov" href="https://www.gov.uk/" aria-hidden="true">
                         <div class="footer__logo"></div>
                 </a>
                 <p class="footer__content">
-                    For citizen and business advice on justice, rights and more visit <a href="#">GOV.UK</a>
+                    For citizen and business advice on justice, rights and more visit <a href="https://www.gov.uk/">GOV.UK <span class="visually-hidden">(opens in a new tab)</span></a>
                 </p>
             </div>
         </div>

--- a/public/app/frontend/src/components/link/link.html.twig
+++ b/public/app/frontend/src/components/link/link.html.twig
@@ -4,6 +4,8 @@ A link element
 
 Available variables:
     - newTab: boolean Whether the link will open in a new tab
+    - newTabVisuallyHidden: string Whether the 'open in a new tab' text should only be shown to screen readers.
+                            Generally should be false, but can be used in special cases like menus.
     - onClick: string A js function to run on click
     - url: string The url for the link
     - label: string The label for the link
@@ -15,6 +17,14 @@ example:
         label: 'Click here'
     }%}
 #}
-<a class="link{{ newTab ? " link--new-tab" : "" }}" href="{{ url }}" {{ newTab ? " target='_blank' rel='noreferrer noopener'" : "" }} {{ onClick ? " onclick='" ~ onClick ~ "'" : "" }}>
-    {{ label }}{{ newTab ? " (opens in new tab)" : "" }}
+<a class="link{{ newTab ? " link--new-tab" : "" }}"
+   href="{{ url }}" {{ newTab ? " target='_blank' rel='noreferrer noopener'" : "" }} {{ onClick ? " onclick='" ~ onClick ~ "'" : "" }}>
+    {{ label }}
+    {% if newTab and newTabVisuallyHidden %}
+        <span class="visually-hidden">
+        (opens in a new tab)
+    </span>
+    {% elseif newTab %}
+        (opens in a new tab)
+    {% endif %}
 </a>

--- a/public/app/frontend/src/components/navigation-main/navigation-main.html.twig
+++ b/public/app/frontend/src/components/navigation-main/navigation-main.html.twig
@@ -33,6 +33,7 @@ example:
                 <li class="navigation-main__link{{ link.active ? " navigation-main__link--active" : "" }}">
                     {% include '@components/link/link.html.twig' with {
                         newTab: link.newTab,
+                        newTabVisuallyHidden: link.newTabVisuallyHidden,
                         onClick: link.onClick,
                         url: link.url,
                         label: link.label,

--- a/public/app/themes/justice/views/partials/footer.html.twig
+++ b/public/app/themes/justice/views/partials/footer.html.twig
@@ -1,35 +1,37 @@
 {% include '@components/footer/footer.html.twig' with {
     links: [
         {
-            url: '#',
+            url: site.url ~ '/help/accessibility',
             label: 'Accessibility',
         },
         {
-            url: '#',
+            url: site.url ~ '/privacy/cookies',
             label: 'Cookies',
         },
         {
-            url: '#',
+            url: 'https://www.gov.uk/government/organisations/ministry-of-justice',
             label: 'Contacts',
+            newTab: true,
+            newTabVisuallyHidden: true,
         },
         {
-            url: '#',
+            url: site.url ~ '/copyright',
             label: 'Copyright',
         },
         {
-            url: '#',
+            url: site.url ~ '/help',
             label: 'Help',
         },
         {
-            url: '#',
+            url: site.url ~ '/privacy',
             label: 'Privacy',
         },
         {
-            url: '#',
+            url: site.url ~ '/ministry-of-justice-webchats',
             label: 'Webchats',
         },
         {
-            url: '#',
+            url: site.url ~ '/website-queries',
             label: 'Website queries',
         },
     ],

--- a/public/app/themes/justice/views/partials/header.html.twig
+++ b/public/app/themes/justice/views/partials/header.html.twig
@@ -5,7 +5,9 @@
         {
             label:'Courts',
             url: 'https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service',
-            onClick: 'gtag && gtag("event", "page_view", { page_title: "Courts", page_location: "' ~ homeUrl ~ '/courts' ~'" });'
+            onClick: 'gtag && gtag("event", "page_view", { page_title: "Courts", page_location: "' ~ homeUrl ~ '/courts' ~'" });',
+            newTab: true,
+            newTabVisuallyHidden: true
         },
         {
             label: 'Procedure rules',
@@ -16,7 +18,9 @@
         {
             label: 'Offenders',
             url: 'https://www.gov.uk/government/organisations/hm-prison-and-probation-service',
-            onClick: 'gtag && gtag("event", "page_view", { page_title: "Courts", page_location: "' ~ homeUrl ~ '/offenders' ~'" });'
+            onClick: 'gtag && gtag("event", "page_view", { page_title: "Courts", page_location: "' ~ homeUrl ~ '/offenders' ~'" });',
+            newTab: true,
+            newTabVisuallyHidden: true
         }
     ],
     search: {


### PR DESCRIPTION
- Add correct links to footer and header in WP
- Add visually hidden prop for links that should open in new tabs - this lets us keep the structure of the header/footer whilst still communicating page changes to screen reader users
- Hide first gov.uk link from footer so that it's not repeated for screen reader users