### PR TITLE
Send 403 errors to sentry, include a link (in Sentry) to Modsec logs.

### DIFF
--- a/public/app/themes/justice/inc/admin.php
+++ b/public/app/themes/justice/inc/admin.php
@@ -25,6 +25,7 @@ class Admin
     public function addHooks()
     {
         add_action('admin_enqueue_scripts', array($this, 'enqueueStyles'));
+        add_action('admin_enqueue_scripts', array($this, 'loadScripts'));
         add_action('admin_menu', [$this, 'removeCustomizer'], 999);
         add_filter('rest_page_query', [$this, 'increaseDropdownLimit'], 9, 2);
         add_action('admin_head', [$this, 'hideNagsForNonAdmins'], 1);
@@ -37,6 +38,34 @@ class Admin
     {
         wp_enqueue_style('justice-admin-style', get_template_directory_uri() . '/dist/css/admin.min.css');
         wp_enqueue_style('justice-editor-style', get_template_directory_uri() . '/dist/css/editor.min.css');
+    }
+
+    /**
+     * Load the admin app script.
+     * 
+     * @return void
+     */
+
+    public function loadScripts(): void
+    {
+
+        $script_asset_path = get_template_directory() . "/dist/php/admin.min.asset.php";
+
+        if (!file_exists($script_asset_path)) {
+            throw new \Error(
+                'You need to run `npm start` or `npm run build` for "app" first.'
+            );
+        }
+
+        $script_asset = require($script_asset_path);
+        wp_register_script(
+            'moj-justice-admin',
+            get_template_directory_uri() . '/dist/admin.min.js',
+            $script_asset['dependencies'],
+            $script_asset['version']
+        );
+
+        wp_enqueue_script('moj-justice-admin');
     }
 
     public static function removeCustomizer(): void

--- a/public/app/themes/justice/package-lock.json
+++ b/public/app/themes/justice/package-lock.json
@@ -9,6 +9,7 @@
             "version": "2.0.0",
             "license": "MIT",
             "devDependencies": {
+                "@sentry/integrations": "^7.114.0",
                 "@tinypixelco/laravel-mix-wp-blocks": "1.2.0",
                 "@wordpress/babel-preset-default": "^7.36.0",
                 "@wordpress/data": "^9.28.0",
@@ -2198,6 +2199,55 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@sentry/core": {
+            "version": "7.114.0",
+            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.114.0.tgz",
+            "integrity": "sha512-YnanVlmulkjgZiVZ9BfY9k6I082n+C+LbZo52MTvx3FY6RE5iyiPMpaOh67oXEZRWcYQEGm+bKruRxLVP6RlbA==",
+            "dev": true,
+            "dependencies": {
+                "@sentry/types": "7.114.0",
+                "@sentry/utils": "7.114.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@sentry/integrations": {
+            "version": "7.114.0",
+            "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.114.0.tgz",
+            "integrity": "sha512-BJIBWXGKeIH0ifd7goxOS29fBA8BkEgVVCahs6xIOXBjX1IRS6PmX0zYx/GP23nQTfhJiubv2XPzoYOlZZmDxg==",
+            "dev": true,
+            "dependencies": {
+                "@sentry/core": "7.114.0",
+                "@sentry/types": "7.114.0",
+                "@sentry/utils": "7.114.0",
+                "localforage": "^1.8.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@sentry/types": {
+            "version": "7.114.0",
+            "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.114.0.tgz",
+            "integrity": "sha512-tsqkkyL3eJtptmPtT0m9W/bPLkU7ILY7nvwpi1hahA5jrM7ppoU0IMaQWAgTD+U3rzFH40IdXNBFb8Gnqcva4w==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@sentry/utils": {
+            "version": "7.114.0",
+            "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.114.0.tgz",
+            "integrity": "sha512-319N90McVpupQ6vws4+tfCy/03AdtsU0MurIE4+W5cubHME08HtiEWlfacvAxX+yuKFhvdsO4K4BB/dj54ideg==",
+            "dev": true,
+            "dependencies": {
+                "@sentry/types": "7.114.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/@tannin/compile": {
@@ -7287,6 +7337,12 @@
                 "node": ">=4.0.0"
             }
         },
+        "node_modules/immediate": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+            "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+            "dev": true
+        },
         "node_modules/immutable": {
             "version": "4.3.6",
             "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
@@ -7817,6 +7873,15 @@
                 "shell-quote": "^1.8.1"
             }
         },
+        "node_modules/lie": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+            "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+            "dev": true,
+            "dependencies": {
+                "immediate": "~3.0.5"
+            }
+        },
         "node_modules/lilconfig": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -7853,6 +7918,15 @@
             },
             "engines": {
                 "node": ">=8.9.0"
+            }
+        },
+        "node_modules/localforage": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+            "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+            "dev": true,
+            "dependencies": {
+                "lie": "3.1.1"
             }
         },
         "node_modules/locate-path": {

--- a/public/app/themes/justice/package.json
+++ b/public/app/themes/justice/package.json
@@ -23,6 +23,7 @@
     },
     "homepage": "https://github.com/ministryofjustice/justice-gov-uk#readme",
     "devDependencies": {
+        "@sentry/integrations": "^7.114.0",
         "@tinypixelco/laravel-mix-wp-blocks": "1.2.0",
         "@wordpress/babel-preset-default": "^7.36.0",
         "@wordpress/data": "^9.28.0",

--- a/public/app/themes/justice/src/js/admin/index.js
+++ b/public/app/themes/justice/src/js/admin/index.js
@@ -1,0 +1,1 @@
+import './request-errors';

--- a/public/app/themes/justice/src/js/admin/request-errors.js
+++ b/public/app/themes/justice/src/js/admin/request-errors.js
@@ -15,9 +15,6 @@ Sentry.addIntegration(
   }),
 );
 
-// Assign window.fetch - It's important to do this *after* HttpClientIntegration has been added to Sentry.
-const { fetch: originalFetch } = window;
-
 /**
  * Add an event processor to Sentry.
  *
@@ -81,6 +78,9 @@ const getModsecLogUrl = (requestUri) => {
 
   return logUrlString;
 };
+
+// Assign window.fetch - It's important to do this *after* HttpClientIntegration has been added to Sentry.
+const { fetch: originalFetch } = window;
 
 /**
  * Intercept fetch requests and handle errors.

--- a/public/app/themes/justice/src/js/admin/request-errors.js
+++ b/public/app/themes/justice/src/js/admin/request-errors.js
@@ -1,0 +1,132 @@
+// npm
+import { HttpClient as HttpClientIntegration } from "@sentry/integrations";
+// Local
+import { roundMins, stringToHash, comboDebounce } from "../utils";
+
+/**
+ * Add the HttpClient integration to Sentry in order to track failed client-side requests.
+ *
+ * @see https://docs.sentry.io/platforms/javascript/configuration/integrations/httpclient
+ */
+
+Sentry.addIntegration(
+  new HttpClientIntegration({
+    failedRequestStatusCodes: [403],
+  }),
+);
+
+// Assign window.fetch - It's important to do this *after* HttpClientIntegration has been added to Sentry.
+const { fetch: originalFetch } = window;
+
+/**
+ * Add an event processor to Sentry.
+ *
+ * Use the processor to alert the user when an error occurred on a client-side (XHR/ajax/fetch) request.
+ * A self-init script has been used to keep variables scoped.
+ *
+ * @see https://docs.sentry.io/platforms/javascript/enriching-events/event-processors/
+ */
+
+(() => {
+  let errorCount = 0;
+  let errorCountAlerted = 0;
+  const message =
+    "Something went wrong. The error has been sent to support. Error count: ";
+
+  const debouncedAlert = comboDebounce(() => {
+    if (errorCountAlerted === errorCount) {
+      return;
+    }
+    errorCountAlerted = errorCount;
+    alert(message + errorCount);
+  }, 2000);
+
+  Sentry.addEventProcessor(function (event, hint) {
+    // If the event has a status code and it's in > 400.
+    if (
+      event.contexts?.response?.status_code &&
+      event.contexts.response.status_code >= 400
+    ) {
+      errorCount++;
+      debouncedAlert();
+    }
+
+    return event;
+  });
+})();
+
+/**
+ * A function to generate an OpenSearch url for reviewing the logs related to a request.
+ * 
+ * @param {string} requestUri
+ * @returns {string}
+ */
+
+const getModsecLogUrl = (requestUri) => {
+  const time = {
+    from: roundMins(new Date(), "down").toISOString(),
+    to: roundMins(new Date(), "up").toISOString(),
+  };
+
+  const query = `${encodeURIComponent(
+    '"transaction.request.uri"',
+  )}:${encodeURIComponent(` "${requestUri}"`)}`;
+
+  const logUrlString =
+    `https://logs.cloud-platform.service.justice.gov.uk/_dashboards/app/discover#/` +
+    `?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'${time.from}',to:'${time.to}'))` +
+    `&_a=(columns:!(transaction.request.uri,transaction.time_stamp,transaction.messages,log),` +
+    `filters:!(),index:b95d8900-dd15-11ed-87c8-170407f57c9c,interval:auto,` +
+    `query:(language:kuery,query:'${query}'),sort:!())`;
+
+  return logUrlString;
+};
+
+/**
+ * Intercept fetch requests and handle errors.
+ *
+ * Fetch requests are used by the WordPress block editor.
+ * If one of these request returns a 403 (for e.g.) then WP does not handle it.
+ *
+ * A 403 is likely a modsec false positive, so send an event to Sentry
+ * and signpost to the full log in OpenSearch.
+ *
+ * @see https://blog.logrocket.com/intercepting-javascript-fetch-api-requests-responses/
+ *
+ * @param {RequestInfo | URL} input
+ * @param {?RequestInit} init
+ * @returns {Promise<Response>}
+ */
+
+window.fetch = async (...args) => {
+  let [resource, config] = args;
+
+  const response = await originalFetch(resource, config);
+
+  if (response.status === 200) {
+    return response;
+  }
+
+  // Parse the request url.
+  const requestUrlObject = new URL(resource);
+  const requestUri = `${requestUrlObject.pathname}${requestUrlObject.search}`;
+
+  // Generate a unique hash base on the request uri and it's body.
+  // Appending this to the Sentry event message prevents similar issues from being grouped.
+  const requestHash = stringToHash(JSON.stringify(config.body) + requestUri);
+
+  // Compose a message for the Sentry issue.
+  const sentryMessage = `Failed client-side fetch request. Request hash ${requestHash}.`;
+
+  // Set the url as context for the Sentry event.
+  Sentry.setContext("cloud_platform_log", {
+    url: getModsecLogUrl(requestUri),
+  });
+
+  Sentry.captureEvent({
+    message: sentryMessage,
+  });
+
+  // response interceptor here
+  return response;
+};

--- a/public/app/themes/justice/src/js/utils.js
+++ b/public/app/themes/justice/src/js/utils.js
@@ -1,0 +1,135 @@
+// cyrb53 (c) 2018 bryc (github.com/bryc). License: Public domain. Attribution appreciated.
+// A fast and simple 64-bit (or 53-bit) string hash function with decent collision resistance.
+// Largely inspired by MurmurHash2/3, but with a focus on speed/simplicity.
+// See https://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript/52171480#52171480
+// https://github.com/bryc/code/blob/master/jshash/experimental/cyrb53.js
+const stringToFloatHash = (str, seed = 0) => {
+  let h1 = 0xdeadbeef ^ seed,
+    h2 = 0x41c6ce57 ^ seed;
+  for (let i = 0, ch; i < str.length; i++) {
+    ch = str.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507);
+  h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507);
+  h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+  // For a single 53-bit numeric return value we could return
+  // 4294967296 * (2097151 & h2) + (h1 >>> 0);
+  // but we instead return the full 64-bit value:
+  return [h2 >>> 0, h1 >>> 0];
+};
+
+// An improved, *insecure* 64-bit hash that's short, fast, and has no dependencies.
+// Output is always 14 characters.
+// https://gist.github.com/jlevy/c246006675becc446360a798e2b2d781
+export const stringToHash = (str, seed = 0) => {
+  const [h2, h1] = stringToFloatHash(str, seed);
+  return h2.toString(36).padStart(7, "0") + h1.toString(36).padStart(7, "0");
+};
+
+/**
+ * A generic throttle function.
+ *
+ * @param {function} mainFunction
+ * @param {number} delay
+ * @returns
+ */
+
+export const throttle = (mainFunction, delay) => {
+  let timerFlag = null; // Variable to keep track of the timer
+
+  // Returning a throttled version
+  return (...args) => {
+    if (timerFlag === null) {
+      // If there is no timer currently running
+      mainFunction(...args); // Execute the main function
+      timerFlag = setTimeout(() => {
+        // Set a timer to clear the timerFlag after the specified delay
+        timerFlag = null; // Clear the timerFlag to allow the main function to be executed again
+      }, delay);
+    }
+  };
+};
+
+/**
+ * Debounce and combo of debounce + throttle.
+ *
+ * @see https://trungvose.com/experience/debounce-throttle-combination/
+ */
+
+// Simplest, dont run once when event haven been seen for 50 ms
+// You have to wait until events end firing before function is run
+function debounce(method, delayMs) {
+  delayMs = delayMs || 50;
+  var timer = null;
+  return function () {
+    var context = this,
+      args = arguments;
+    clearTimeout(timer);
+    timer = setTimeout(function () {
+      method.apply(context, args);
+    }, delayMs);
+  };
+}
+
+// Somewhat more complicated. function is fired right away, then for maximum
+// every 250 ms. You might potentially have to wait 250 ms after last seen event
+export const comboDebounce = (fn, threshold) => {
+  threshold = threshold || 250;
+  var last, deferTimer;
+
+  var db = debounce(fn);
+  return function () {
+    var now = +new Date(),
+      args = arguments;
+    if (!last || (last && now < last + threshold)) {
+      clearTimeout(deferTimer);
+      db.apply(this, args);
+      deferTimer = setTimeout(function () {
+        last = now;
+        fn.apply(this, args);
+      }, threshold);
+    } else {
+      last = now;
+      fn.apply(this, args);
+    }
+  };
+};
+
+/**
+ * A function to round a date's minutes up or down.
+ *
+ * @param {?Date} originalDate
+ * @param {number} resolution
+ * @param {'up'|'down'} direction
+ * @returns Date
+ */
+
+export const roundMins = (
+  originalDate = new Date(),
+  direction = "up",
+  resolution = 30,
+) => {
+  // Make a clone so as not to mutate the original value.
+  const date = new Date(originalDate.getTime());
+
+  // Set secs and ms to 0;
+  date.setSeconds(0);
+  date.setMilliseconds(0);
+
+  if (direction === "down") {
+    date.setMinutes(Math.floor(date.getMinutes() / resolution) * resolution);
+  } else {
+    // As we've rounded down secs and ms, add 1 to the mins here, then ceil.
+    // e.g.
+    // - When zero-ing in previous step: 10:00:30:123 -> 10:00:00:000
+    // - Here: 10:01:00:000 -> 10:30:00:000
+    date.setMinutes(
+      Math.ceil((date.getMinutes() + 1) / resolution) * resolution,
+    );
+  }
+
+  return date;
+};

--- a/public/app/themes/justice/webpack.mix.js
+++ b/public/app/themes/justice/webpack.mix.js
@@ -6,6 +6,7 @@ mix.setPublicPath('./dist/')
 mix
     .block("src/js/block-editor.js", "dist")
     .js('src/js/app.js', 'dist/app.min.js')
+    .js('src/js/admin/index.js', 'dist/admin.min.js')
     .js('src/js/login.js', 'dist/js/login.min.js')
     /** patch code for CCFW **/
     .js('src/patch/js/ccfw-cookie-manage.js', 'dist/patch/js/ccfw-cookie-manage.js')


### PR DESCRIPTION
This can be tested by manually by:
- changing modsec ingress rules on development.
- triggering modsec false positives
- reviewing issue on Sentry
- Following link from Sentry UI to full log entry in OpenSearch.