### PR TITLE
CDPT-1991 Get cache secrets into staging and production.

### DIFF
--- a/deploy/production/config.yml
+++ b/deploy/production/config.yml
@@ -8,3 +8,4 @@ data:
   WP_HOME: 'https://www.justice.gov.uk'
   WP_SITEURL: 'https://www.justice.gov.uk/wp'
   WP_LOOPBACK: 'http://localhost:8080'
+  WP_REDIS_DISABLED: "true"

--- a/deploy/production/deployment.tpl.yml
+++ b/deploy/production/deployment.tpl.yml
@@ -92,6 +92,16 @@ spec:
                 secretKeyRef:
                   name: rds-output
                   key: database_password
+            - name: CACHE_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: elasticache-output
+                  key: primary_endpoint_address
+            - name: CACHE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: elasticache-output
+                  key: auth_token
           envFrom:
             - configMapRef:
                 name: ${KUBE_NAMESPACE}

--- a/deploy/staging/deployment.tpl.yml
+++ b/deploy/staging/deployment.tpl.yml
@@ -79,6 +79,16 @@ spec:
                 secretKeyRef:
                   name: rds-output
                   key: database_password
+            - name: CACHE_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: elasticache-output
+                  key: primary_endpoint_address
+            - name: CACHE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: elasticache-output
+                  key: auth_token
           envFrom:
             - configMapRef:
                 name: ${KUBE_NAMESPACE}


### PR DESCRIPTION
This PR gets the Elasticache credentials into the fpm container.

On production `WP_REDIS_DISABLED: "true"` has been set until QA on staging has passed.