### PR TITLE
CDPT-2073: Active indicator is missing on menu links

### DIFF
--- a/public/app/themes/justice/page.php
+++ b/public/app/themes/justice/page.php
@@ -9,7 +9,6 @@ use MOJ\Justice\DynamicMenu;
 use MOJ\Justice\Content;
 
 get_header();
-get_footer();
 
 $postMeta = new PostMeta(get_the_ID());
 
@@ -139,9 +138,13 @@ if ($postMeta->sideHasPanels('left')) {
 $templates = !$sidePanelsLeft ? ['templates/basic--one-sidebar.html.twig'] : ['templates/basic--two-sidebars.html.twig'];
 $context = Timber::context([
     'title' => get_the_title(),
+    'homeUrl' => home_url(),
+    'permalink' => get_the_permalink(),
     'breadcrumbs' => $breadcrumbs,
     'updatedDate' => $postMeta->getMeta('_show_updated_at') ? $postMeta->getModifiedAt() : null,
     'sidePanelsRight' => $sidePanelsRight,
     'sidePanelsLeft' => $sidePanelsLeft,
 ]);
 Timber::render($templates, $context);
+
+get_footer();

--- a/public/app/themes/justice/page_home.php
+++ b/public/app/themes/justice/page_home.php
@@ -5,7 +5,6 @@
  */
 
 get_header();
-get_footer();
 
 $templates = ['templates/home.html.twig'];
 $blockContent = [
@@ -52,3 +51,5 @@ $context = Timber::context([
     'content' => get_the_content(),
 ]);
 Timber::render($templates, $context);
+
+get_footer();

--- a/public/app/themes/justice/views/partials/header.html.twig
+++ b/public/app/themes/justice/views/partials/header.html.twig
@@ -12,7 +12,7 @@
         {
             label: 'Procedure rules',
             url: homeUrl ~ '/courts/procedure-rules',
-            active: homeUrl ~ '/courts/procedure-rules' starts with permalink,
+            active: permalink starts with homeUrl ~ '/courts/procedure-rules',
             onclick : null
         },
         {


### PR DESCRIPTION
- Fix logic that displays the indicator (starts with permalink -> permalink starts with)
- Move footer function to the bottom of page/page_home