### PR TITLE
CDPT-2078 Add liveness and readiness health checks.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,11 @@ RUN addgroup -g 101 -S nginx; adduser -u 101 -S -D -G nginx nginx
 RUN mkdir /sock && \
     chown nginx:nginx /sock
 
+# Copy our healthcheck scripts and set them to executable
+COPY bin/fpm-*.sh /usr/local/bin/fpm-health/
+
+RUN chmod +x /usr/local/bin/fpm-health/*
+
 ## Change directory
 WORKDIR /usr/local/etc/php-fpm.d
 
@@ -16,18 +21,6 @@ RUN rm zz-docker.conf && \
 
 ## Set our pool configuration
 COPY deploy/config/php-pool.conf pool.conf
-
-# Temporarily add relay & phpredis (alternative redis modules that are faster than predis), for object caching.
-# https://relay.so/
-
-COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
-RUN install-php-extensions relay
-
-# https://github.com/phpredis/phpredis
-
-RUN apk add --no-cache pcre-dev $PHPIZE_DEPS \
-        && pecl install redis \
-        && docker-php-ext-enable redis.so
 
 WORKDIR /var/www/html
 

--- a/bin/fpm-liveness.sh
+++ b/bin/fpm-liveness.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+# Exit with code 1 if any php process has been running for more than 1 hour.
+# shellcheck disable=SC2009
+if [ "$(ps -o time,comm | grep -c '.*h.*php-fpm')" -gt 0 ]; then exit 1; fi

--- a/bin/fpm-readiness.sh
+++ b/bin/fpm-readiness.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env ash
+
+# Send a ping request via fast-cgi. Use an empty environment with `env -i`.
+PING_RESPONSE=$(env -i SCRIPT_NAME=/ping SCRIPT_FILENAME=/ping REQUEST_METHOD=GET cgi-fcgi -bind -connect /sock/fpm.sock | tail -1);
+
+# Exit with code 1 if the ping response was not 'pong'.
+if [ "$PING_RESPONSE" != 'pong' ]; then exit 1; fi;
+
+# Request the fpm status via fast-cgi.
+FPM_STATUS=$(env -i SCRIPT_NAME=/status SCRIPT_FILENAME=/status REQUEST_METHOD=GET cgi-fcgi -bind -connect /sock/fpm.sock);
+
+# Exit with code 1 if the status is 'Could not connect to /sock/fpm.sock'.
+if [ "$(echo "$FPM_STATUS" | grep -c 'Could not connect')" -gt 0 ]; then exit 1; fi;

--- a/bin/fpm-status.sh
+++ b/bin/fpm-status.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+
+# This is a helper script to assist in understanding long running (crashed) fpm processes.
+
+# This script will output details of all running processes e.g:
+
+# pid:                  146880
+# state:                Idle
+# start time:           27/Sep/2024:09:38:00 +0100
+# start since:          6
+# requests:             1
+# request duration:     1426
+# request method:       GET
+# request URI:          /wp/wp-admin/admin-ajax.php
+# content length:       0
+# user:                 -
+# script:               /var/www/html/public/wp/wp-admin/admin-ajax.php
+# last request cpu:     0.00
+# last request memory:  2097152
+
+env -i SCRIPT_NAME=/status SCRIPT_FILENAME=/status QUERY_STRING="full" REQUEST_METHOD=GET cgi-fcgi -bind -connect /sock/fpm.sock

--- a/deploy/config/php-pool.conf
+++ b/deploy/config/php-pool.conf
@@ -7,12 +7,16 @@ listen.owner = nginx
 listen.group = nginx
 listen.mode = 0660
 
+ping.path=/ping
+ping.response=pong
+
 pm = dynamic
 pm.start_servers = 10
 pm.min_spare_servers = 5
 pm.max_spare_servers = 10
 pm.max_requests = 500
 pm.max_children = 50
+pm.status_path = /status;
 
 [global]
 daemonize = no

--- a/deploy/config/server.conf
+++ b/deploy/config/server.conf
@@ -117,6 +117,14 @@ server {
         fastcgi_cache_purge pub01 "$real_scheme$request_method$host$1";
     }
 
+    ##
+    # HEALTH CHECK
+    ##
+    # This location covers liveness and readiness for the nginx container.
+    location = /health {
+        return 200;
+    }
+
     gzip on;
     gzip_disable "msie6";
 

--- a/deploy/demo/deployment.tpl.yml
+++ b/deploy/demo/deployment.tpl.yml
@@ -44,6 +44,14 @@ spec:
             limits:
               cpu: 500m
               memory: 200Mi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
 
         - name: fpm
           image: "${ECR_URL}:${IMAGE_TAG_FPM}"
@@ -63,6 +71,26 @@ spec:
               memory: 500Mi
           securityContext:
             runAsUser: 101
+          # Check frequently during startup, so that scaling up can happen as fast as possible.
+          startupProbe:
+            exec:
+              command:
+              - /usr/local/bin/fpm-health/fpm-readiness.sh
+            failureThreshold: 20
+            periodSeconds: 5
+          # Don't route traffic to this pod if the container is not ready.
+          readinessProbe:
+            exec:
+              command:
+              - /usr/local/bin/fpm-health/fpm-readiness.sh
+            periodSeconds: 10
+            failureThreshold: 1
+          # Restart the container if it fails liveness script.
+          livenessProbe:
+            exec:
+              command:
+              - /usr/local/bin/fpm-health/fpm-liveness.sh
+            periodSeconds: 10
           env:
             - name: S3_BUCKET_NAME
               valueFrom:

--- a/deploy/development/deployment.tpl.yml
+++ b/deploy/development/deployment.tpl.yml
@@ -37,6 +37,14 @@ spec:
               mountPath: /var/www/html/public/app/uploads
             - name: php-socket
               mountPath: /sock
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
         - name: fpm
           image: ${ECR_URL}:${IMAGE_TAG_FPM}
           ports:
@@ -48,6 +56,26 @@ spec:
               mountPath: /sock
           securityContext:
             runAsUser: 101
+          # Check frequently during startup, so that scaling up can happen as fast as possible.
+          startupProbe:
+            exec:
+              command:
+              - /usr/local/bin/fpm-health/fpm-readiness.sh
+            failureThreshold: 20
+            periodSeconds: 5
+          # Don't route traffic to this pod if the container is not ready.
+          readinessProbe:
+            exec:
+              command:
+              - /usr/local/bin/fpm-health/fpm-readiness.sh
+            periodSeconds: 10
+            failureThreshold: 1
+          # Restart the container if it fails liveness script.
+          livenessProbe:
+            exec:
+              command:
+              - /usr/local/bin/fpm-health/fpm-liveness.sh
+            periodSeconds: 10
           env:
             - name: S3_BUCKET_NAME
               valueFrom:

--- a/deploy/production/deployment.tpl.yml
+++ b/deploy/production/deployment.tpl.yml
@@ -44,6 +44,14 @@ spec:
             limits:
               cpu: 500m
               memory: 200Mi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
 
         - name: fpm
           image: "${ECR_URL}:${IMAGE_TAG_FPM}"
@@ -61,6 +69,26 @@ spec:
               memory: 500Mi
           securityContext:
             runAsUser: 101
+          # Check frequently during startup, so that scaling up can happen as fast as possible.
+          startupProbe:
+            exec:
+              command:
+              - /usr/local/bin/fpm-health/fpm-readiness.sh
+            failureThreshold: 20
+            periodSeconds: 5
+          # Don't route traffic to this pod if the container is not ready.
+          readinessProbe:
+            exec:
+              command:
+              - /usr/local/bin/fpm-health/fpm-readiness.sh
+            periodSeconds: 10
+            failureThreshold: 1
+          # Restart the container if it fails liveness script.
+          livenessProbe:
+            exec:
+              command:
+              - /usr/local/bin/fpm-health/fpm-liveness.sh
+            periodSeconds: 10
           env:
             - name: S3_BUCKET_NAME
               valueFrom:

--- a/deploy/staging/deployment.tpl.yml
+++ b/deploy/staging/deployment.tpl.yml
@@ -37,6 +37,14 @@ spec:
               mountPath: /var/www/html/public/app/uploads
             - name: php-socket
               mountPath: /sock
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
         - name: fpm
           image: ${ECR_URL}:${IMAGE_TAG_FPM}
           ports:
@@ -48,6 +56,26 @@ spec:
               mountPath: /sock
           securityContext:
             runAsUser: 101
+          # Check frequently during startup, so that scaling up can happen as fast as possible.
+          startupProbe:
+            exec:
+              command:
+              - /usr/local/bin/fpm-health/fpm-readiness.sh
+            failureThreshold: 20
+            periodSeconds: 5
+          # Don't route traffic to this pod if the container is not ready.
+          readinessProbe:
+            exec:
+              command:
+              - /usr/local/bin/fpm-health/fpm-readiness.sh
+            periodSeconds: 10
+            failureThreshold: 1
+          # Restart the container if it fails liveness script.
+          livenessProbe:
+            exec:
+              command:
+              - /usr/local/bin/fpm-health/fpm-liveness.sh
+            periodSeconds: 10
           env:
             - name: S3_BUCKET_NAME
               valueFrom:

--- a/public/app/object-cache.php
+++ b/public/app/object-cache.php
@@ -1238,7 +1238,9 @@ class WP_Object_Cache {
 	 *               not with a message describing the issue.
 	 */
 	public function check_client_dependencies() {
-		if ( ! class_exists( 'Redis' ) ) {
+		// *
+		// Check for the correct Redis extension.
+		if ( ! class_exists( WP_REDIS_USE_RELAY ? 'Relay\Relay' : 'Redis' ) ) {
 			return 'Warning! PHPRedis extension is unavailable, which is required by WP Redis object cache.';
 		}
 		return true;


### PR DESCRIPTION
This PR adds heath checks for the php-fpm and nginx containers.

It then adds these endpoints and scripts to the kubernetes deployments.

These health checks are very similar to those on the intranet main branch. With the only difference being nginx readiness and liveness probes are going to the same uri (`/health`).

There are also 2 changes related to redis, they are duplicates from this pending PR https://github.com/ministryofjustice/justice-gov-uk/pull/282/files