### PR TITLE
Add overflow-wrap to ensure long links in the body don't stretch the …

### DIFF
--- a/public/app/frontend/style.scss
+++ b/public/app/frontend/style.scss
@@ -502,6 +502,7 @@ $iconSizes: (
 //
 @mixin rich-text {
     @include body;
+    overflow-wrap: break-word;
 
     ul:not(.navigation-sections__list) {
         @include ul-list;


### PR DESCRIPTION
Tiny change to stop long links from stretching the page width on mobile.