### PR TITLE
CDPT-2369 Make php-fpm container fs read only.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ RUN rm zz-docker.conf && \
 ## Set our pool configuration
 COPY deploy/config/php-pool.conf pool.conf
 
+# Create volumes for so that the directories are are writeable when the container is run in read-only mode.
+VOLUME /tmp /var/www/html/public/app/uploads
+
 WORKDIR /var/www/html
 
 ###

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN rm zz-docker.conf && \
 ## Set our pool configuration
 COPY deploy/config/php-pool.conf pool.conf
 
-# Create volumes for so that the directories are are writeable when the container is run in read-only mode.
+# Create volumes for so that the directories are writeable when the container is in read-only mode.
 VOLUME /tmp /var/www/html/public/app/uploads
 
 WORKDIR /var/www/html

--- a/deploy/demo/deployment.tpl.yml
+++ b/deploy/demo/deployment.tpl.yml
@@ -21,29 +21,35 @@ spec:
         app: ${KUBE_NAMESPACE}
     spec:
       volumes:
-        - name: uploads
-          emptyDir: { }
         - name: php-socket
           emptyDir: { }
       terminationGracePeriodSeconds: 35
       serviceAccountName: ${KUBE_NAMESPACE}-service
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        seccompProfile:
+          type: "RuntimeDefault"
       containers:
         - name: nginx
           image: ${ECR_URL}:${IMAGE_TAG_NGINX}
           ports:
             - containerPort: 8080
           volumeMounts:
-            - name: uploads
-              mountPath: /var/www/html/public/app/uploads
             - name: php-socket
               mountPath: /sock
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: 
+              drop: ["ALL"]
           resources:
-            requests:
-              cpu: 500m
-              memory: 200Mi
             limits:
               cpu: 500m
-              memory: 200Mi
+              memory: 250Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
           readinessProbe:
             httpGet:
               path: /health
@@ -54,23 +60,22 @@ spec:
               port: 8080
 
         - name: fpm
-          image: "${ECR_URL}:${IMAGE_TAG_FPM}"
-          ports:
-            - containerPort: 9000
+          image: ${ECR_URL}:${IMAGE_TAG_FPM}
           volumeMounts:
-            - name: uploads
-              mountPath: /var/www/html/public/app/uploads
             - name: php-socket
               mountPath: /sock
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: 
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
           resources:
+            limits:
+              cpu: 1000m
+              memory: 500Mi
             requests:
               cpu: 500m
               memory: 500Mi
-            limits:
-              cpu: 500m
-              memory: 500Mi
-          securityContext:
-            runAsUser: 101
           # Check frequently during startup, so that scaling up can happen as fast as possible.
           startupProbe:
             exec:

--- a/deploy/development/deployment.tpl.yml
+++ b/deploy/development/deployment.tpl.yml
@@ -21,22 +21,35 @@ spec:
         app: ${KUBE_NAMESPACE}
     spec:
       volumes:
-        - name: uploads
-          emptyDir: { }
         - name: php-socket
           emptyDir: { }
       terminationGracePeriodSeconds: 35
       serviceAccountName: ${KUBE_NAMESPACE}-service
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        seccompProfile:
+          type: "RuntimeDefault"
       containers:
         - name: nginx
           image: ${ECR_URL}:${IMAGE_TAG_NGINX}
           ports:
             - containerPort: 8080
           volumeMounts:
-            - name: uploads
-              mountPath: /var/www/html/public/app/uploads
             - name: php-socket
               mountPath: /sock
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: 
+              drop: ["ALL"]
+          resources:
+            limits:
+              cpu: 500m
+              memory: 250Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
           readinessProbe:
             httpGet:
               path: /health
@@ -45,17 +58,24 @@ spec:
             httpGet:
               path: /health
               port: 8080
+
         - name: fpm
           image: ${ECR_URL}:${IMAGE_TAG_FPM}
-          ports:
-            - containerPort: 9000
           volumeMounts:
-            - name: uploads
-              mountPath: /var/www/html/public/app/uploads
             - name: php-socket
               mountPath: /sock
           securityContext:
-            runAsUser: 101
+            allowPrivilegeEscalation: false
+            capabilities: 
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 500Mi
+            requests:
+              cpu: 500m
+              memory: 500Mi
           # Check frequently during startup, so that scaling up can happen as fast as possible.
           startupProbe:
             exec:

--- a/deploy/production/deployment.tpl.yml
+++ b/deploy/production/deployment.tpl.yml
@@ -21,27 +21,33 @@ spec:
         app: ${KUBE_NAMESPACE}
     spec:
       volumes:
-        - name: uploads
-          emptyDir: { }
         - name: php-socket
           emptyDir: { }
       terminationGracePeriodSeconds: 35
       serviceAccountName: ${KUBE_NAMESPACE}-service
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        seccompProfile:
+          type: "RuntimeDefault"
       containers:
         - name: nginx
           image: ${ECR_URL}:${IMAGE_TAG_NGINX}
           ports:
             - containerPort: 8080
           volumeMounts:
-            - name: uploads
-              mountPath: /var/www/html/public/app/uploads
             - name: php-socket
               mountPath: /sock
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: 
+              drop: ["ALL"]
           resources:
-            requests:
+            limits:
               cpu: 500m
               memory: 200Mi
-            limits:
+            requests:
               cpu: 500m
               memory: 200Mi
           readinessProbe:
@@ -54,21 +60,22 @@ spec:
               port: 8080
 
         - name: fpm
-          image: "${ECR_URL}:${IMAGE_TAG_FPM}"
+          image: ${ECR_URL}:${IMAGE_TAG_FPM}
           volumeMounts:
-            - name: uploads
-              mountPath: /var/www/html/public/app/uploads
             - name: php-socket
               mountPath: /sock
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: 
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
           resources:
-            requests:
-              cpu: 600m
-              memory: 500Mi
             limits:
               cpu: 1000m
               memory: 500Mi
-          securityContext:
-            runAsUser: 101
+            requests:
+              cpu: 600m
+              memory: 500Mi
           # Check frequently during startup, so that scaling up can happen as fast as possible.
           startupProbe:
             exec:

--- a/deploy/staging/deployment.tpl.yml
+++ b/deploy/staging/deployment.tpl.yml
@@ -21,22 +21,35 @@ spec:
         app: ${KUBE_NAMESPACE}
     spec:
       volumes:
-        - name: uploads
-          emptyDir: { }
         - name: php-socket
           emptyDir: { }
       terminationGracePeriodSeconds: 35
       serviceAccountName: ${KUBE_NAMESPACE}-service
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        seccompProfile:
+          type: "RuntimeDefault"
       containers:
         - name: nginx
           image: ${ECR_URL}:${IMAGE_TAG_NGINX}
           ports:
             - containerPort: 8080
           volumeMounts:
-            - name: uploads
-              mountPath: /var/www/html/public/app/uploads
             - name: php-socket
               mountPath: /sock
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: 
+              drop: ["ALL"]
+          resources:
+            limits:
+              cpu: 500m
+              memory: 250Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
           readinessProbe:
             httpGet:
               path: /health
@@ -45,17 +58,24 @@ spec:
             httpGet:
               path: /health
               port: 8080
+
         - name: fpm
           image: ${ECR_URL}:${IMAGE_TAG_FPM}
-          ports:
-            - containerPort: 9000
           volumeMounts:
-            - name: uploads
-              mountPath: /var/www/html/public/app/uploads
             - name: php-socket
               mountPath: /sock
           securityContext:
-            runAsUser: 101
+            allowPrivilegeEscalation: false
+            capabilities: 
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 500Mi
+            requests:
+              cpu: 500m
+              memory: 500Mi
           # Check frequently during startup, so that scaling up can happen as fast as possible.
           startupProbe:
             exec:


### PR DESCRIPTION
This PR makes the filesystem of the php-fpm container readonly. 
It also adds various security contexts to improve security of the pods.