### PR TITLE
CDPT-2268: Horizontal lists no longer have the 'is-style-page-nav' class

### DIFF
--- a/public/app/themes/justice/src/js/block-editor/remove-custom-class.js
+++ b/public/app/themes/justice/src/js/block-editor/remove-custom-class.js
@@ -11,10 +11,10 @@ import { addFilter } from "@wordpress/hooks";
  */
 
 const removeCustomClassNameSupport = (settings, name) => {
-  if (
-    !name.startsWith("core/") ||
-    settings.supports?.customClassName === false
-  ) {
+  // Blocks that are allowed to have custom class name support, e.g. the list block and the horizontal styling variant.
+  const allowed = ['core/list'];
+
+  if (!name.startsWith("core/") || settings.supports?.customClassName === false || allowed.includes(name)) {
     return settings;
   }
 


### PR DESCRIPTION
- Add an exception to the removeCustomClassNameSupport function for the list block