### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG version_nginx=1.26.2
+
 FROM ministryofjustice/wordpress-base-fpm:latest AS base-fpm
 
 # Make the Nginx user available in this container
@@ -27,9 +29,10 @@ VOLUME /tmp /var/www/html/public/app/uploads
 
 WORKDIR /var/www/html
 
+
 ###
 
-FROM nginx:1.26.2-alpine AS nginx-module-builder
+FROM nginx:${version_nginx}-alpine AS nginx-module-builder
 
 SHELL ["/bin/ash", "-exo", "pipefail", "-c"]
 
@@ -47,9 +50,10 @@ RUN apk update \
     BUILT_MODULES="$BUILT_MODULES $(echo cachepurge | tr '[A-Z]' '[a-z]' | tr -d '[/_\-\.\t ]')"; \
     echo "BUILT_MODULES=\"$BUILT_MODULES\"" > /tmp/packages/modules.env
 
+
 ###
 
-FROM nginxinc/nginx-unprivileged:1.26-alpine AS base-nginx
+FROM nginxinc/nginx-unprivileged:${version_nginx}-alpine AS base-nginx
 
 USER root
 


### PR DESCRIPTION
Snyk error cites an Nginx version mismatch when building the Dockerfile.

This update offers a consistent version provided by a Docker ARG.