### PR TITLE
CDPT-2574 Remove duplicated redis scheme code

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -172,11 +172,6 @@ if (!isset($_SERVER['CACHE_TIMEOUT'])) {
     $_SERVER['CACHE_TIMEOUT'] = 2500;
 }
 
-if (!empty($_SERVER['CACHE_HOST'])) {
-    // Prefix scheme to the host, default to tls.
-    $_SERVER['CACHE_HOST'] = (env('CACHE_SCHEME') ?: 'tls') . '://' . $_SERVER['CACHE_HOST'];
-}
-
 // Disable the caching if CACHE_HOST is empty, or via WP_REDIS_DISABLED - in case of emergency.
 Config::define('WP_REDIS_DISABLED', empty($_SERVER['CACHE_HOST']) || env('WP_REDIS_DISABLED'));
 // Set default expiry to 1hour.


### PR DESCRIPTION
This PR removes duplicate code, the redis scheme is now only applied in `public/app/object-cache.php`, to match how it works in the intranet codebase.