### PR TITLE
Enable redis cache on production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ DB_USER=mysql
 DB_PASSWORD=mysql
 
 CACHE_HOST=redis
-CACHE_SCHEME=redis
+CACHE_SCHEME=''
 
 COMPOSER_USER=circleci
 COMPOSER_PASS=some_password

--- a/deploy/production/config.yml
+++ b/deploy/production/config.yml
@@ -8,7 +8,6 @@ data:
   WP_HOME: 'https://www.justice.gov.uk'
   WP_SITEURL: 'https://www.justice.gov.uk/wp'
   WP_LOOPBACK: 'http://localhost:8080'
-  WP_REDIS_DISABLED: "true"
   # See Azure Setup in the README for more information on how to get these values.
   # The following IDs are not private, they form part of the publicly visible oauth login url.
   OAUTH_CLIENT_ID: "3313c87a-399d-4130-a505-37c996721009"


### PR DESCRIPTION
This PR enables redis cache on production.

There is also an update to CACHE_SCHEME  in example.env - as this is required no that we are using the php Redis class instead of Relay.