### PR TITLE
CDPT-2574 Temp. disable redis

### DIFF
--- a/deploy/config/php-pool.conf
+++ b/deploy/config/php-pool.conf
@@ -18,6 +18,10 @@ pm.max_requests = 500
 pm.max_children = 50
 pm.status_path = /status;
 
+; Log a stack trace to stderr for slow queries.
+request_slowlog_timeout = 8s;
+slowlog = /proc/self/fd/2;
+
 [global]
 daemonize = no
 emergency_restart_threshold = 10

--- a/deploy/production/config.yml
+++ b/deploy/production/config.yml
@@ -8,6 +8,7 @@ data:
   WP_HOME: 'https://www.justice.gov.uk'
   WP_SITEURL: 'https://www.justice.gov.uk/wp'
   WP_LOOPBACK: 'http://localhost:8080'
+  WP_REDIS_DISABLED: "true"
   # See Azure Setup in the README for more information on how to get these values.
   # The following IDs are not private, they form part of the publicly visible oauth login url.
   OAUTH_CLIENT_ID: "3313c87a-399d-4130-a505-37c996721009"


### PR DESCRIPTION
This PR disable WP-Redis object cache, because it was increasing P99 latency to 10 seconds.

This PR also adds logging requests that take > ~8s

---

Further investigation is required to work out why the latency is increasing so much for a sub-set of requests.

This should include reviewing slow request logs, and adding logging for cache misses. 