### PR TITLE
Fix cron url returning 404

### DIFF
--- a/deploy/config/server.conf
+++ b/deploy/config/server.conf
@@ -127,6 +127,8 @@ server {
     location ~* ^/wp/wp-cron.php {
         allow 127.0.0.1;
         deny all;
+        include /etc/nginx/php-fpm.conf;
+        fastcgi_pass fpm;
     }
 
     ##


### PR DESCRIPTION
Currently, the requests related to scheduling are failing.

This is because the endpoint `/wp/wp-cron.php` is being hit, but nginx is trying to serve that file, instead of passing the request to `fpm`.

This PR is a change to the `server.conf` to match `local/server.conf`.