### PR TITLE
CDPT-1705 Purge cache after content updates (amends)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -197,6 +197,7 @@ FROM base-fpm AS build-fpm
 WORKDIR /var/www/html
 COPY --chown=nginx:nginx ./config ./config
 COPY --chown=nginx:nginx ./public ./public
+COPY --chown=nginx:nginx wp-cli.yml wp-cli.yml
 
 # Replace paths with dependencies from build-fpm-composer
 ARG path="/var/www/html"

--- a/public/app/mu-plugins/cluster-helper/commands.php
+++ b/public/app/mu-plugins/cluster-helper/commands.php
@@ -99,5 +99,5 @@ if (defined('WP_CLI') && WP_CLI) {
     WP_CLI::add_command('cluster-helper', $cluster_helper_commands);
 
     // 2. Register object as a function for the callable parameter.
-    WP_CLI::add_command('cluster-helper', 'ClusterHelperCommands');
+    WP_CLI::add_command('cluster-helper', 'MOJ\ClusterHelperCommands');
 }


### PR DESCRIPTION
This PR:

- Adds wp-cli.yml to the fpm container image. So that WP_CLI commands can be run from the project root.
- Correctly sets up the namespaced WP_CLI command: `MOJ\ClusterHelperCommand`