### PR TITLE
CDPT-1705 Purge cache after content updates (amends)

### DIFF
--- a/deploy/config/local/server.conf
+++ b/deploy/config/local/server.conf
@@ -12,7 +12,7 @@ map $http_x_forwarded_proto $real_scheme {
 # Configure fastcgi cache
 fastcgi_cache_path /var/run/nginx-cache levels=1:2 keys_zone=pub01:100m inactive=60m;
 fastcgi_cache_use_stale updating error timeout invalid_header http_500;
-fastcgi_cache_key "$real_scheme$request_method$host$request_uri";
+fastcgi_cache_key "$request_method$host$request_uri";
 
 upstream fpm {
     server unix:/sock/fpm.sock;
@@ -142,7 +142,7 @@ server {
     ##
 
     location ~ /purge-cache(/.*) {
-        fastcgi_cache_purge pub01 "$real_scheme$request_method$host$1";
+        fastcgi_cache_purge pub01 "$request_method$host$1";
     }
 
     ##

--- a/deploy/config/server.conf
+++ b/deploy/config/server.conf
@@ -16,7 +16,7 @@ upstream fpm {
 # Configure fastcgi cache
 fastcgi_cache_path /var/run/nginx-cache levels=1:2 keys_zone=pub01:100m inactive=60m;
 fastcgi_cache_use_stale updating error timeout invalid_header http_500;
-fastcgi_cache_key "$real_scheme$request_method$host$request_uri";
+fastcgi_cache_key "$request_method$host$request_uri";
 
 server {
     listen       8080;
@@ -137,7 +137,7 @@ server {
 
     location ~ /purge-cache(/.*) {
         limit_req zone=flood burst=5 nodelay;
-        fastcgi_cache_purge pub01 "$real_scheme$request_method$host$1";
+        fastcgi_cache_purge pub01 "$request_method$host$1";
     }
 
     ##


### PR DESCRIPTION
This PR removes the `$real_scheme` part of the nginx cache key.

This is because http and https responses are the same, and we do not serve http traffic.

It will allow us to clear cache bymaking a http request to the purge-cach endpoint, from an internal network.

The same thing has been done with the intranet's cache keys.

fastcgi_cache_key "$request_method$host$request_uri:$cookie_dw_agency";