### PR TITLE
CDPT-2941 Fix duplicate download details

### DIFF
--- a/public/app/frontend/src/components/file-download/file-download.html.twig
+++ b/public/app/frontend/src/components/file-download/file-download.html.twig
@@ -26,4 +26,7 @@ example:
     {% if format %}
         <span class="file-download__details">({{ language ? language ~ ", " : "" }}{{ format }}{{ filesize ? ", " ~ filesize : "" }})</span>
     {% endif %}
+{# Keep the following HTML comment, it assists in removing file details that an editor has input into the content editor  #}
+{# It is used to identify the end this component, subsequently we can safely remove a duplicate string of "(PDF)". #}
+<!-- /.file-download -->
 </div>

--- a/public/app/themes/justice/functions.php
+++ b/public/app/themes/justice/functions.php
@@ -79,7 +79,6 @@ new Justice\Comments();
 new Justice\Content();
 new Justice\ContentQuality();
 new Justice\Core();
-new Justice\Documents();
 new Justice\Layout();
 new Justice\Posts();
 new Justice\Redirects();
@@ -92,6 +91,10 @@ new Justice\Theme();
 
 $block_editor = new Justice\BlockEditor();
 $block_editor->addHooks();
+
+$documents = new Justice\Documents();
+$documents->addHooks();
+$documents->removeHooks();
 
 $post_meta = new Justice\PostMeta();
 $post_meta->addHooks();

--- a/public/app/themes/justice/inc/documents/documents.php
+++ b/public/app/themes/justice/inc/documents/documents.php
@@ -52,8 +52,6 @@ class Documents
 
     public function __construct()
     {
-        $this->addHooks();
-        $this->removeHooks();
         $this->post_meta = new PostMeta();
         $this->utils = new Utils();
     }

--- a/public/app/themes/justice/inc/templates.php
+++ b/public/app/themes/justice/inc/templates.php
@@ -41,7 +41,6 @@ class Templates
     public function __construct()
     {
         libxml_use_internal_errors(true);
-        $this->addHooks();
         $this->documents = new Documents();
         $this->content = new Content();
     }
@@ -49,6 +48,7 @@ class Templates
     public function addHooks(): void
     {
         add_action('render_block', [$this, 'replaceWordpressBlocks'], 10, 2);
+        add_action('render_block', [$this, 'replaceDuplicateDownloadDetails'], 11, 1);
     }
 
     /**
@@ -63,7 +63,7 @@ class Templates
     public function replaceWordpressBlocks(string $block_content, array $block): string
     {
         // Only target certain blocks and only run in the main loop on pages/posts
-        if ((in_array($block['blockName'], $this->blocks)) && ( is_single() || is_page() ) && in_the_loop() && is_main_query()) {
+        if ((in_array($block['blockName'], $this->blocks)) && (is_single() || is_page()) && in_the_loop() && is_main_query()) {
             $html = $block['innerHTML'];
 
             if (!$html) {
@@ -285,5 +285,29 @@ class Templates
             'link' => $href,
             'language' => $language,
         ];
+    }
+
+    /**
+     * Replace duplicate "(PDF)" text following a file download block
+     * 
+     * This is used to remove the duplicate "(PDF)" text that appears after the file download block.
+     * It looks for the specific HTML comment that marks the end of the file download block and
+     * replaces the "(PDF)" text that follows it with an empty string.
+     * 
+     * @param string $block_content The content of the block to be processed
+     * @return string The modified block content with duplicate "(PDF)" text removed
+     */
+    public static function replaceDuplicateDownloadDetails(string $block_content): string
+    {
+        // If the block content is empty, return it as is
+        if (empty($block_content)) {
+            return $block_content;
+        }
+
+        // Regex to replace the strings:
+        // - `<!-- /.file-download --> </div> (PDF)`  -> `</div>`
+        // - `<!-- /.file-download --> </span> (PDF)` -> `</span>`
+        $regex_pattern = '/\N*<!-- \/\.file-download -->\v(\s*)<\/(div|span)> \(PDF\)/';
+        return preg_replace($regex_pattern, '$1</$2>', $block_content);
     }
 }

--- a/spec/Unit/TemplatesTest.php
+++ b/spec/Unit/TemplatesTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Support\UnitTester;
+use MOJ\Justice\Templates;
+
+use WP_Mock;
+
+final class TemplatesTest extends \Codeception\Test\Unit
+{
+    protected UnitTester $tester;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        WP_Mock::setUp();
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        WP_Mock::tearDown();
+    }
+
+    public function testReplaceDuplicateDownloadDetails(): void
+    {
+        // Define some HTML, where the "(PDF)" text appears multiple times.
+        // This simulates a scenario where the same file download details are repeated.
+        $html_pre_process = '<div class="file-download">
+            <i class="file-download__icon icon-pdf--sm" aria-hidden="true"></i>
+            <a class="file-download__link" href="http://justice.docker/__data/assets/pdf_file/0006/177846/cpr-166-pd-update.pdf">
+                <span class="file-download__prefix visually-hidden">Download</span>
+                PD making document
+            </a>
+            <span class="file-download__details">(PDF)</span>
+            <!-- /.file-download -->
+        </div> (PDF)';
+
+        // Pass the HTML to the method that processes it.
+        $html_post_process = Templates::replaceDuplicateDownloadDetails($html_pre_process);
+
+        // Define the expected HTML after processing, where the duplicate "(PDF)" text is removed.
+        $expected_html = '<div class="file-download">
+            <i class="file-download__icon icon-pdf--sm" aria-hidden="true"></i>
+            <a class="file-download__link" href="http://justice.docker/__data/assets/pdf_file/0006/177846/cpr-166-pd-update.pdf">
+                <span class="file-download__prefix visually-hidden">Download</span>
+                PD making document
+            </a>
+            <span class="file-download__details">(PDF)</span>
+        </div>';
+
+        // Assert that the processed HTML matches the expected HTML.
+        $this->assertEquals($html_post_process, $expected_html);
+
+        // Test for multiple occurrences of the duplicated details in a single string.
+        $html_post_process_2 = Templates::replaceDuplicateDownloadDetails("$html_pre_process\n\r$html_pre_process");
+
+        // The expected HTML should still be the same, but now it appears twice in the string.
+        $expected_html_2 = "$expected_html\n\r$expected_html";
+
+        // Assert that the processed HTML matches the expected HTML for the second case.
+        $this->assertEquals($html_post_process_2, $expected_html_2);
+    }
+}

--- a/spec/Unit/_bootstrap.php
+++ b/spec/Unit/_bootstrap.php
@@ -16,3 +16,4 @@ require_once $theme_root_dir . '/inc/content-quality/issues/anchor.php';
 require_once $theme_root_dir . '/inc/content-quality/issues/empty-heading.php';
 require_once $theme_root_dir . '/inc/content-quality/issues/thead.php';
 require_once $theme_root_dir . '/inc/post-meta/post-meta.php';
+require_once $theme_root_dir . '/inc/templates.php';


### PR DESCRIPTION
Also, in this PR, `addHooks` and `removeHooks` have been moved from the `Documents` `constructor` to `functions.php`.

This is so that they are not run multiple times when `new Documents` is called multiple times.