### PR TITLE
CDPT-2864 Fix styling on gov.uk link in footer

### DIFF
--- a/public/app/frontend/src/components/footer/footer.scss
+++ b/public/app/frontend/src/components/footer/footer.scss
@@ -28,7 +28,7 @@
 
     &__link {
         a {
-            @include link('light');
+            @include link('light', 'menu');
             @include spacing('padding', 2, 'top');
             @include spacing('padding', 2, 'bottom');
 

--- a/public/app/frontend/src/components/navigation-main/navigation-main.scss
+++ b/public/app/frontend/src/components/navigation-main/navigation-main.scss
@@ -34,7 +34,7 @@
         }
 
         a {
-            @include link('light');
+            @include link('light', 'menu');
             @include spacing('padding', 2, 'top');
             @include spacing('padding', 2, 'bottom');
 

--- a/public/app/frontend/src/components/navigation-secondary/navigation-secondary.scss
+++ b/public/app/frontend/src/components/navigation-secondary/navigation-secondary.scss
@@ -43,7 +43,7 @@
     }
 
     &__link {
-        @include link('light');
+        @include link('light', 'menu');
 
         display: flex;
         align-items: center;

--- a/public/app/frontend/style.scss
+++ b/public/app/frontend/style.scss
@@ -324,7 +324,7 @@ $iconSizes: (
     }
 }
 
-@mixin link($type: 'dark') {
+@mixin link($type: 'dark', $context: 'default') {
     @include body;
     outline: none;
     color: var(--justice-primary-black);
@@ -348,14 +348,16 @@ $iconSizes: (
             text-decoration: none;
         }
         @if ($type == 'light') {
-            font-family: var(--body-font);
             color: var(--justice-primary-white);
-            text-decoration: none;
             &:hover,
             &:visited,
             &:active {
                 color: var(--justice-primary-white);
             }
+        }
+        @if ($context == 'menu') {
+            font-family: var(--body-font);
+            text-decoration: none;
             &:hover {
                 text-decoration: underline;
                 outline: none;


### PR DESCRIPTION
This PR modifies the link mixin so that the light colour variant does not imply any change to the underline.

An additional property is added for $context and 'menu', that is added to all 3 places where `@include link('light');` was used - except for the 1 place where the gov.uk link is.