### PR TITLE
CDPT-2866 Secondary menu label to reflect the open state (amend).

### DIFF
--- a/public/app/frontend/src/components/navigation-secondary/index.js
+++ b/public/app/frontend/src/components/navigation-secondary/index.js
@@ -13,7 +13,7 @@ export default function () {
     const nav = el.querySelector('.navigation-secondary__nav');
     button.addEventListener('click', () => {
         // Get the current state, so that the following actions don't go out of sync.
-        const willOpen = nav.classList.contains('navigation-secondary__nav--open');
+        const willOpen = !nav.classList.contains('navigation-secondary__nav--open');
         // Toggle the open class on the nav element.
         nav.classList.toggle('navigation-secondary__nav--open');
         // Set the aria-expanded attribute on the button.


### PR DESCRIPTION
This PR fixes a bug that I introduced in the [previous PR](https://github.com/ministryofjustice/justice-gov-uk/pull/353) - where the value of willOpen is the opposite of what is it intended to be.