### PR TITLE
CDPT-2872 side bar navigation amend

### DIFF
--- a/public/app/frontend/src/components/navigation-secondary/navigation-secondary.html.twig
+++ b/public/app/frontend/src/components/navigation-secondary/navigation-secondary.html.twig
@@ -65,7 +65,7 @@ example:
                 ">
 
                 {% if item.children %}
-                    <div class="navigation-secondary__list-item-wrapper">
+                    <div class="navigation-secondary__list-item-wrapper navigation-secondary__list-item-wrapper--has-sublist">
                         <a class="navigation-secondary__link navigation-secondary__link--has-sublist" role="link" 
                             {{ item.active ? "aria-current='page' aria-disabled='true'" : "href='#{ item.url }'" }}
                         >

--- a/public/app/frontend/src/components/navigation-secondary/navigation-secondary.scss
+++ b/public/app/frontend/src/components/navigation-secondary/navigation-secondary.scss
@@ -92,12 +92,11 @@
             // See `... &__button ... &--sublist` below.
             margin-right: 2.875rem;
             &::after {
-                // Update the inset to account for the button width.
+                // Override the inset to account for the button width.
                 inset: 0 2.875rem 0 0;
             }
         }
     }
-
 
     &__button {
         @include arrow-button('light');
@@ -127,21 +126,21 @@
             right: 0;
             top: 0;
             bottom: 0;
-            
-            // This width is 2 * $gutter-mobile, plus 14px for the arrow button. 
+
+            // This width is 2 * $gutter-mobile, plus 14px for the arrow button.
             width: 2.875rem;
 
             @media screen and (min-width: $justice-lg) {
                 @include arrow-button('dark');
 
-                // Set width here to override the 100% width that is 
+                // Set width here to override the 100% width that is
                 // applied by the `arrow-button` mixin.
                 width: 2.875rem;
-                
-                // Use important on padding here, to get a higher specificity 
+
+                // Use important on padding here, to get a higher specificity
                 // than the padding applied by the `arrow-button` mixin.
-                padding-left: $gutter-mobile!important;
-                padding-right: $gutter-mobile!important;
+                padding-left: $gutter-mobile !important;
+                padding-right: $gutter-mobile !important;
             }
         }
     }
@@ -186,6 +185,20 @@
         padding-right: $gutter-mobile;
         @media screen and (min-width: $justice-lg) {
             @include spacing('padding', 2);
+
+            // Create an after element to be used for the active state background.
+            // Use a pseudo-element to aloww for an offset when we have a sublist toggle button.
+            &::after {
+                content: '';
+                position: absolute;
+                inset: 0;
+            }
+
+            // If the item has a sublist, we need to account for the button width.
+            &--has-sublist::after {
+                // Override the inset to account for the button width.
+                inset: 0 2.875rem 0 0;
+            }
         }
     }
 
@@ -205,7 +218,7 @@
                 }
             }
             @media screen and (min-width: $justice-lg) {
-                > #{$this}__list-item-wrapper {
+                > #{$this}__list-item-wrapper::after {
                     background-color: var(--justice-primary-grey);
                 }
                 > #{$this}__list-item-wrapper > #{$this}__link {

--- a/public/app/themes/justice/inc/navigation-secondary.php
+++ b/public/app/themes/justice/inc/navigation-secondary.php
@@ -83,6 +83,9 @@ class NavigationSecondary
             return $items;
         }
 
+        // Procedure rules is a seed page for the secondary navigation, get it's ID here.
+        $procedure_rules_id = get_page_by_path('courts/procedure-rules')->ID;
+
         // The items aren't cached, so populate the items array.
         $items = [
             [
@@ -91,10 +94,10 @@ class NavigationSecondary
                 'url' => 'https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service',
             ],
             [
-                'id' => "procedure-rules-" . get_page_by_path('courts/procedure-rules')->ID,
+                'id' => "procedure-rules-$procedure_rules_id",
                 'label' => 'Procedure rules',
-                'url' => '/courts/procedure-rules',
-                'children' => $this->getChildPagesForNavigation(get_page_by_path('courts/procedure-rules')->ID),
+                'url' => get_permalink($procedure_rules_id),
+                'children' => $this->getChildPagesForNavigation($procedure_rules_id),
             ],
             [
                 'id' => "www-gov-uk-government-organisations-hm-prison-and-probation-service",


### PR DESCRIPTION
In this PR:

**1.** Adds the full URL for the /courts/procedure-rules link, so that it is marked as active and expanded correctly.

Before and after controller update, on the procedure rule page:

<img width="280" height="222" alt="image" src="https://github.com/user-attachments/assets/49eeb1cb-3ef3-4961-bf55-2f902a0e5c1c" /> 
<img width="280" height="222" alt="image" src="https://github.com/user-attachments/assets/5b4ac788-f491-480c-b63b-c104321f7423" />

---

**2.** Correctly styles the active item when it has a sublist

Before and after style update:

<img width="280" height="271" alt="image" src="https://github.com/user-attachments/assets/cbdd92c3-a050-43a4-9976-b56d0bb07e54" /> <img width="280" height="271" alt="image" src="https://github.com/user-attachments/assets/8bc284d8-e1ea-4c32-af36-bd7d0f00e0fe" />
