### PR TITLE
CDPT-2881 Move download info into link

### DIFF
--- a/public/app/frontend/src/components/file-download/file-download.html.twig
+++ b/public/app/frontend/src/components/file-download/file-download.html.twig
@@ -16,10 +16,6 @@ example:
         filesize: '120 KbB',
         language: 'Welsh'
     }%}
-
-    TODO
-    [ ] Find and test all places where this file is included
-
 #}<a class="file-download" href={{ link }}>
     {{- "" -}}
     <i class="file-download__icon icon-{{ format|lower }}--em" aria-hidden="true"></i>

--- a/public/app/frontend/src/components/file-download/file-download.html.twig
+++ b/public/app/frontend/src/components/file-download/file-download.html.twig
@@ -24,7 +24,7 @@ example:
     <span class="file-download__prefix visually-hidden">Download</span>
 
     {{- "" -}}
-    <span class="file-download__words">
+    <span class="file-download__text">
         {{- filename -}}
 
         {%- if format -%}

--- a/public/app/frontend/src/components/file-download/file-download.html.twig
+++ b/public/app/frontend/src/components/file-download/file-download.html.twig
@@ -18,28 +18,28 @@ example:
         filesize: '120 KbB',
         language: 'Welsh'
     }%}
-#}
 
-{% if variant == "inline" %}
-    <span class="file-download file-download--inline">
-{% else %}
-    <div class="file-download file-download--block">
-{% endif %}
-    <a class="file-download__link" href={{ link }}>
-        {{- "" -}}
-        <i class="file-download__icon icon-{{ format|lower }}--{{ variant == "inline" ? "em" : "sm"}}" aria-hidden="true"></i>
-        {{- "" -}}
-        <span class="file-download__prefix visually-hidden">Download</span>
+    TODO
+    [ ] Find and test all places where this file is included
+
+#}<a class="file-download" href={{ link }}>
+    {{- "" -}}
+    <i class="file-download__icon icon-{{ format|lower }}--em" aria-hidden="true"></i>
+    {{- "" -}}
+
+    <span class="file-download__prefix visually-hidden">Download</span>
+
+    {{- "" -}}
+    <span class="file-download__words">
         {{- filename -}}
-    </a>
-    {% if format %}
-        <span class="file-download__details">({{ language ? language ~ ", " : "" }}{{ format }}{{ filesize ? ", " ~ filesize : "" }})</span>
-    {% endif %}
+
+        {%- if format -%}
+            {{- " " -}}({{ language ? language ~ ", " : "" }}{{ format }}{{ filesize ? ", " ~ filesize : "" }})
+        {%- endif -%}
+    </span>
+    {{- "" -}}
+
 {# Keep the following HTML comment, it assists in removing file details that an editor has input into the content editor  #}
 {# It is used to identify the end this component, subsequently we can safely remove a duplicate string of "(PDF)". #}
 <!-- /.file-download -->
-{% if variant == "inline" %}
-    </span>
-{% else %}
-    </div>
-{% endif %}
+</a>

--- a/public/app/frontend/src/components/file-download/file-download.html.twig
+++ b/public/app/frontend/src/components/file-download/file-download.html.twig
@@ -3,7 +3,6 @@
 A file (pdf) for download
 
 Available variables:
-    - variant: 'block'|'inline' The display variant of the component
     - format: 'PDF'|'ZIP'|'DOC' The file format
     - link: string The link to the file
     - filename: string The name of the file
@@ -11,7 +10,6 @@ Available variables:
     - language: string The language of the file if different to the language of the page
 example:
     {% include '@components/file-download/file-download.html.twig' with {
-        variant: 'inline'
         format: 'PDF',
         link: '#',
         filename: 'User manual',

--- a/public/app/frontend/src/components/file-download/file-download.scss
+++ b/public/app/frontend/src/components/file-download/file-download.scss
@@ -14,7 +14,7 @@
         top: 0.125em;
     }
 
-    &__words {
+    &__text {
         // Override the previously set `white-space` to allow wrapping
         white-space: normal;
     }

--- a/public/app/frontend/src/components/file-download/file-download.scss
+++ b/public/app/frontend/src/components/file-download/file-download.scss
@@ -1,54 +1,21 @@
 @import '../../../style';
 
 .file-download {
-    // Style the inline variation by default
+    @include link;
 
-    // `display` will be overridden by the block variation
-    display: inline;
+    // Keep the icon next to the text
+    white-space: nowrap;
 
-    &__link {
-        @include link;
-        // `display` will be overridden by the block variation
-        display: inline;
-    }
-    
-    &__icon {       
+    &__icon {
         @include spacing('margin', 1, 'right');
-
+        // Override the default icon styles
         display: inline-flex!important;
         position: relative;
-
-        // `top` will be overridden by the block variation
         top: 2px;
     }
-    
-    &__details {
-        @include body;
 
-        // `display` will be overridden by the block variation
-        display: inline;
-    }
-
-    // Block variation
-    &--block {
-        @include spacing('margin', 4, 'top');
-
-        display: flex;
-        flex-wrap: wrap;
-    }
-
-    &--block & {
-        &__link {
-            @include spacing('margin', 1, 'right');
-            display: flex;
-        }
-        &__icon {
-            top: 0;
-        }
-        &__details {
-            display: flex;
-            flex-wrap: nowrap;
-            width: fit-content;
-        }
+    &__words {
+        // Override the previously set `white-space` to allow wrapping
+        white-space: normal;
     }
 }

--- a/public/app/frontend/src/components/file-download/file-download.scss
+++ b/public/app/frontend/src/components/file-download/file-download.scss
@@ -11,7 +11,7 @@
         // Override the default icon styles
         display: inline-flex!important;
         position: relative;
-        top: 2px;
+        top: 0.125em;
     }
 
     &__words {

--- a/public/app/frontend/src/components/file-download/file-download.stories.js
+++ b/public/app/frontend/src/components/file-download/file-download.stories.js
@@ -19,7 +19,6 @@ const Template = (args) => {
 
 export const Default = Template.bind({});
 Default.args = {
-    variant: 'block',
     format: 'PDF',
     link: '#',
     filesize: '167 KB',
@@ -35,7 +34,6 @@ Welsh.args = {
 export const InParagraph = Template.bind({});
 InParagraph.args = {
     ...Default.args,
-    variant: 'inline',
 };
 InParagraph.decorators = [
     (Story) => {
@@ -49,7 +47,6 @@ InParagraph.decorators = [
 export const TextWrap = Template.bind({});
 TextWrap.args = {
     ...Default.args,
-    variant: 'inline',
     filename: 'Practice Direction 51L New Bill of Costs Pilot Excel version of precedent'
 };
 TextWrap.decorators = [

--- a/public/app/frontend/src/components/search-result-card/search-result-card.stories.js
+++ b/public/app/frontend/src/components/search-result-card/search-result-card.stories.js
@@ -16,3 +16,13 @@ Default.args = {
     description:
         '…testing a new bill of costs, Precedent AA, to reflect the costs management and costs budgeting procedures is introduced. Practice Direction 51L New Bill of Costs Pilot Excel version of…',
 };
+
+export const FileDownload = Template.bind({});
+FileDownload.args = {
+    title: 'Civil Procedure Rules - Update 7',
+    url: 'https://www.justice.gov.uk/courts/procedure-rules/civil/documents/cpr_update7_pdf.zip',
+    date: '16 May 2024',
+    isDocument: true,
+    format: 'PDF',
+    filesize: '167 KB',
+};

--- a/public/app/frontend/src/components/search-result-list/search-result-list.stories.js
+++ b/public/app/frontend/src/components/search-result-list/search-result-list.stories.js
@@ -32,5 +32,13 @@ Default.args = {
             description:
                 '…is being tested across five regions, at eight Family Court locations. The amendment extends the testing sites to Central London, Liverpool and Reading Family Courts in order to increase the…',
         },
+        {
+            title: 'Civil Procedure Rules - Update 7',
+            url: 'https://www.justice.gov.uk/courts/procedure-rules/civil/documents/cpr_update7_pdf.zip',
+            date: '16 May 2024',
+            isDocument: true,
+            format: 'PDF',
+            filesize: '167 KB',
+        },
     ],
 };

--- a/public/app/frontend/src/components/sidebar-block/sidebar-block.scss
+++ b/public/app/frontend/src/components/sidebar-block/sidebar-block.scss
@@ -141,20 +141,11 @@
     }
 
     .file-download {
+        display: flex;
         margin-top: 0;
-        display: inline;
 
         &__icon {
-            float: left;
-            display: inline;
-        }
-
-        &__link {
-            display: inline;
-        }
-
-        &__details {
-            margin-left: 0;
+            flex-shrink: 0;
         }
     }
 

--- a/public/app/themes/justice/inc/templates.php
+++ b/public/app/themes/justice/inc/templates.php
@@ -334,10 +334,9 @@ class Templates
             return $block_content;
         }
 
-        // Regex to replace the strings:
-        // - `<!-- /.file-download --> </div> (PDF)`  -> `</div>`
-        // - `<!-- /.file-download --> </span> (PDF)` -> `</span>`
-        $regex_pattern = '/\N*<!-- \/\.file-download -->\v(\s*)<\/(div|span)>\s{0,1}\(PDF\)/';
-        return preg_replace($regex_pattern, '$1</$2>', $block_content);
+        // Regex to replace the string:
+        // - `<!-- /.file-download --> </a> (PDF)` -> `</a>`
+        $regex_pattern = '/<!-- \/\.file-download -->\v(\s*)?<\/a>\s{0,1}\(PDF\)/';
+        return preg_replace($regex_pattern, '$1</a>', $block_content);
     }
 }

--- a/public/app/themes/justice/inc/templates.php
+++ b/public/app/themes/justice/inc/templates.php
@@ -308,7 +308,6 @@ class Templates
         }
 
         return [
-            'variant' => 'inline',
             'format' => $format,
             'filesize' => $filesize,
             'filename' => $label,

--- a/public/app/themes/justice/inc/templates.php
+++ b/public/app/themes/justice/inc/templates.php
@@ -336,6 +336,6 @@ class Templates
         // Regex to replace the string:
         // - `<!-- /.file-download --> </a> (PDF)` -> `</a>`
         $regex_pattern = '/<!-- \/\.file-download -->\v(\s*)?<\/a>\s{0,1}\(PDF\)/';
-        return preg_replace($regex_pattern, '$1</a>', $block_content);
+        return preg_replace($regex_pattern, '</a>', $block_content);
     }
 }

--- a/public/app/themes/justice/views/partials/file-download.html.twig
+++ b/public/app/themes/justice/views/partials/file-download.html.twig
@@ -1,5 +1,4 @@
 {% include '@components/file-download/file-download.html.twig' with {
-    variant: variant,
     format: format,
     link: link,
     filesize: filesize,

--- a/spec/Unit/TemplatesTest.php
+++ b/spec/Unit/TemplatesTest.php
@@ -29,28 +29,22 @@ final class TemplatesTest extends \Codeception\Test\Unit
     {
         // Define some HTML, where the "(PDF)" text appears multiple times.
         // This simulates a scenario where the same file download details are repeated.
-        $html_pre_process = '<div class="file-download">
-            <i class="file-download__icon icon-pdf--sm" aria-hidden="true"></i>
-            <a class="file-download__link" href="http://justice.docker/__data/assets/pdf_file/0006/177846/cpr-166-pd-update.pdf">
-                <span class="file-download__prefix visually-hidden">Download</span>
-                PD making document
-            </a>
-            <span class="file-download__details">(PDF)</span>
-            <!-- /.file-download -->
-        </div> (PDF)';
+        $html_pre_process = '<a class="file-download" href="#">
+            <i class="file-download__icon icon-pdf--em" aria-hidden="true"></i>
+            <span class="file-download__prefix visually-hidden">Download</span>
+            <span class="file-download__text">CPR email address list (PDF, 167 KB)</span>
+        <!-- /.file-download -->
+        </a> (PDF)';
 
         // Pass the HTML to the method that processes it.
         $html_post_process = Templates::replaceDuplicateDownloadDetails($html_pre_process);
 
         // Define the expected HTML after processing, where the duplicate "(PDF)" text is removed.
-        $expected_html = '<div class="file-download">
-            <i class="file-download__icon icon-pdf--sm" aria-hidden="true"></i>
-            <a class="file-download__link" href="http://justice.docker/__data/assets/pdf_file/0006/177846/cpr-166-pd-update.pdf">
-                <span class="file-download__prefix visually-hidden">Download</span>
-                PD making document
-            </a>
-            <span class="file-download__details">(PDF)</span>
-        </div>';
+        $expected_html = '<a class="file-download" href="#">
+            <i class="file-download__icon icon-pdf--em" aria-hidden="true"></i>
+            <span class="file-download__prefix visually-hidden">Download</span>
+            <span class="file-download__text">CPR email address list (PDF, 167 KB)</span>
+        </a>';
 
         // Assert that the processed HTML matches the expected HTML.
         $this->assertEquals($html_post_process, $expected_html);


### PR DESCRIPTION
This PR moves the download info e.g. `(PDF, 167 KB)` from after the file-download link, into inside the link.

Since this change, the inline and block variants of the file-download component are no longer necessary and have been removed.