### PR TITLE
CDPT-2868 Increase footer text contrast for 'Citizen and business advice'

### DIFF
--- a/public/app/frontend/src/components/footer/footer.scss
+++ b/public/app/frontend/src/components/footer/footer.scss
@@ -55,7 +55,7 @@
         @include h3;
 
         font-weight: var(--heading-font-normal);
-        color: var(--justice-secondary-blue);
+        color: var(--justice-secondary-light-blue);
     }
 
     &__gov {

--- a/public/app/frontend/src/documentation/design/Colours.mdx
+++ b/public/app/frontend/src/documentation/design/Colours.mdx
@@ -34,7 +34,8 @@ Update the colour palette in `public/app/frontend/documentation/design/Colours.m
         colors={{
             '--justice-secondary-grey': '#7e7e74',
             '--justice-secondary-dark-grey': '#5c5c54',
-            '--justice-secondary-blue': '#4e6280',
+            '--justice-secondary-blue': '#5f789b',
+            '--justice-secondary-light-blue': '#6c8ab2',
             '--justice-secondary-grey-blue': '#eff0f2',
         }}
     />

--- a/public/app/frontend/style.scss
+++ b/public/app/frontend/style.scss
@@ -10,6 +10,7 @@
     --justice-secondary-grey: #7e7e74;
     --justice-secondary-dark-grey: #5c5c54; 
     --justice-secondary-blue: #5F789B;
+    --justice-secondary-light-blue: #6c8ab2;
     --justice-secondary-grey-blue: #eff0f2;
 
     // Links


### PR DESCRIPTION
This PR

- The link for  'Citizen and business advice' has an updated colour.
- The colours page in Story book is corrected and updated.
