### PR TITLE
CDPT-2882 Add 'Link text uses raw URLs' to content quality framework

### DIFF
--- a/.github/pages/editing/content-quality.md
+++ b/.github/pages/editing/content-quality.md
@@ -171,6 +171,26 @@ If necessary, make reference to the [Tables section](/editing/block-editor.html#
 - how to add a header section to a table
 - how to remove a table column or row
 
+
+### Link text uses raw URLs
+
+This issue occurs when a hyperlink displays the full URL as its visible text. While this may be visually understandable to sighted users familiar with web addresses, it can create unnecessary cognitive load for users relying on screen readers. Long URLs are often read out character-by-character or as an unintelligible string, offering little context about the link’s destination.
+
+This practice also affects users with cognitive impairments, who benefit from clear and descriptive link text that communicates purpose without requiring additional interpretation.
+
+---
+
+On the Pages admin screen, the issue will be displayed as "There is 1 link with a URL for the text".
+
+---
+
+Replace raw URLs used as visible link text with descriptive phrases that clearly indicate the link’s purpose or destination. This improves accessibility and usability for all users, especially those using assistive technologies.
+
+Avoid vague phrases like "click here" or "read more". Instead, use meaningful link text that provides context.
+
+e.g. replace the link text "https://demo.justice.gov.uk/courts/procedure-rules/civil/rules/part04" with "Civil Procedure Rules Part 4".
+
+
 ### Table without header section
 
 This issue occurs when a table is created without a header section. A header section is required for accessibility reasons, as it helps screen readers understand the structure of the table.

--- a/public/app/themes/justice/inc/content-quality/content-quality.php
+++ b/public/app/themes/justice/inc/content-quality/content-quality.php
@@ -17,6 +17,7 @@ require_once 'issues/email-text.php';
 require_once 'issues/empty-heading.php';
 require_once 'issues/incomplete-thead.php';
 require_once 'issues/thead.php';
+require_once 'issues/url-text.php';
 
 class ContentQuality
 {
@@ -73,6 +74,7 @@ class ContentQuality
         new ContentQualityIssueEmptyHeading();
         new ContentQualityIssueIncompleteThead();
         new ContentQualityIssueThead();
+        new ContentQualityIssueUrlText();
 
         // Add more issues here as needed.
         // e.g. new ContentQualityIssueAltText();

--- a/public/app/themes/justice/inc/content-quality/issues/url-text.php
+++ b/public/app/themes/justice/inc/content-quality/issues/url-text.php
@@ -14,7 +14,7 @@ final class ContentQualityIssueUrlText extends ContentQualityIssue
 {
     const ISSUE_SLUG = 'url-text';
 
-    const ISSUE_LABEL = 'Inaccessible URL link text';
+    const ISSUE_LABEL = 'Links with a URL for the text';
 
 
     /**

--- a/public/app/themes/justice/inc/content-quality/issues/url-text.php
+++ b/public/app/themes/justice/inc/content-quality/issues/url-text.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * This class is for content quality checks and reports.
+ */
+
+namespace MOJ\Justice;
+
+defined('ABSPATH') || exit;
+
+require_once 'issue.php';
+
+final class ContentQualityIssueUrlText extends ContentQualityIssue
+{
+    const ISSUE_SLUG = 'url-text';
+
+    const ISSUE_LABEL = 'Inaccessible URL link text';
+
+
+    /**
+     * Get the pages with inaccessible UTL text issues.
+     *
+     * This function runs an SQL query to find pages with `>http...</a` or `>https...</a` strings.
+     *
+     * @return array An array of pages with URL link text issues.
+     */
+    public function getPagesWithIssues(): array
+    {
+        $pages_with_issue = [];
+        $transient_updates = [];
+
+        global $wpdb;
+
+        $query = "
+            SELECT ID, post_content, post_modified, options.option_value AS inaccessible_url_text_count
+            FROM {$wpdb->posts}
+            -- To save us from running get_transient in a php loop, 
+            -- we can join the options table to get the transient value here
+            LEFT JOIN {$wpdb->options} AS options 
+            ON options.option_name = CONCAT('_transient_moj:content-quality:issue:url-text:', ID)
+            -- Where clauses
+            WHERE
+                -- options value should be null or not 0
+                ( options.option_value IS NULL OR options.option_value != '0' ) AND
+                -- Post type should be page 
+                post_type = 'page' AND
+                -- Post content should contain a closing element tag (>)
+                -- Followed by optional whitespace
+                -- Followed by a URL that contains https:// or http://
+                -- e.g. <a href='https://example.com'>Example</a> should not match
+                -- <a href='https://example.com'>https://example.com</a> should match
+                post_content RLIKE '>\s*(https?)'
+        ";
+
+        foreach ($wpdb->get_results($query) as $page) :
+            $inaccessible_url_text_count = is_null($page->inaccessible_url_text_count) ? null : (int)$page->inaccessible_url_text_count;
+
+            if (is_null($inaccessible_url_text_count)) {
+                // The table didn't contain a transient value, so we need to check the content.
+                $inaccessible_url_text_count = $this->getInaccessibleUrlLinksFromContent($page->post_content);
+                // Add the value to the transient updates array, this will be used in a bulk update later.
+                $transient_updates["$this->transient_key:{$page->ID}"] = $inaccessible_url_text_count;
+            }
+
+            // If the value is > 0, add it to the pages_with_issue array.
+            if ($inaccessible_url_text_count) {
+                $pages_with_issue[$page->ID] = $inaccessible_url_text_count;
+            }
+        endforeach;
+
+        if (sizeof($transient_updates)) {
+            $expiry = time() + $this->transient_duration;
+            $this->bulkSetTransientInDatabase($transient_updates, $expiry);
+        }
+
+        return $pages_with_issue;
+    }
+
+
+    /**
+     * Append issues for a specific page.
+     *
+     * This function checks if the page has issues and appends them to the issues array.
+     *
+     * @param array $issues The current issues array.
+     * @param int $post_id The ID of the post to check.
+     * @return array The issues array with the anchor issues appended.
+     */
+    public function appendPageIssues($issues, $post_id)
+    {
+        // Load the pages with issues - don't run this on construct, as it's an expensive operation.
+        $this->loadPagesWithIssues();
+
+        if (empty($this->pages_with_issue[$post_id])) {
+            return $issues;
+        }
+
+        $count = $this->pages_with_issue[$post_id];
+
+        $issues[] =  sprintf(_n('There is %d URL link with inaccessible text', 'There are %d URL links with inaccessible text', $count, 'justice'), $count);
+
+        return $issues;
+    }
+
+    /**
+     * Get inaccessibly formatted URL links found in the content.
+     *
+     * This function checks for links where the text starts with http or https.
+     *
+     * @param string $content The content to check.
+     * @return int The number of inaccessibly formatted URL links found in the content.
+     */
+    public static function getInaccessibleUrlLinksFromContent(string $content): int
+    {
+        if (empty($content)) {
+            return 0;
+        }
+
+        // Use a regex to find links where the text label starts with http or https.
+        // e.g. >https://example.com</a> should match and >Example</a> should not match
+        $pattern = '/>\s*(https?:\/\/[^\s<]+)\s*<\/a/i';
+
+        // Find all matches in the content.
+        preg_match_all($pattern, $content, $matches);
+
+        // If matches are found, return the count.
+        return empty($matches[1]) ? 0 :  count($matches[1]);
+    }
+}

--- a/public/app/themes/justice/inc/content-quality/issues/url-text.php
+++ b/public/app/themes/justice/inc/content-quality/issues/url-text.php
@@ -97,7 +97,7 @@ final class ContentQualityIssueUrlText extends ContentQualityIssue
 
         $count = $this->pages_with_issue[$post_id];
 
-        $issues[] =  sprintf(_n('There is %d URL link with inaccessible text', 'There are %d URL links with inaccessible text', $count, 'justice'), $count);
+        $issues[] =  sprintf(_n('There is %d link with a URL for the text', 'There are %d URL links with a URL for the text', $count, 'justice'), $count);
 
         return $issues;
     }

--- a/spec/Unit/ContentQualityIssueUrlTextTest.php
+++ b/spec/Unit/ContentQualityIssueUrlTextTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\Support\UnitTester;
+use MOJ\Justice\ContentQualityIssueURLText;
+use WP_Mock;
+
+final class ContentQualityIssueURLTextTest extends \Codeception\Test\Unit
+{
+
+    protected UnitTester $tester;
+
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        WP_Mock::setUp();
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        WP_Mock::tearDown();
+    }
+
+    public function testGetInaccessibleUrlLinksFromContent(): void
+    {
+        $instance = ContentQualityIssueURLText::class;
+
+        // Test empty content
+        $this->assertSame(0, $instance::getInaccessibleUrlLinksFromContent(''));
+
+        // Test content without email links
+        $this->assertSame(0, $instance::getInaccessibleUrlLinksFromContent('<p>No URL links here.</p>'));
+
+        // Test content with a correctly formatted URL link
+        $content = '<p>... via the Legislation website at:  <a href="http://www.legislation.gov.uk/id/uksi/2021/196">The Civil Procedure (Amendment No. 2) Rules 2021</a></p>';
+        $this->assertSame(0, $instance::getInaccessibleUrlLinksFromContent($content));
+        
+        // Test content with an invalid text content
+        $content = '<p>... via the Legislation website at:  <a href="http://www.legislation.gov.uk/id/uksi/2021/196">http://www.legislation.gov.uk/id/uksi/2021/196</a></p>';
+        $this->assertSame(1, $instance::getInaccessibleUrlLinksFromContent($content));
+
+        // Test content with multiple links and valid text content
+        $content = '<p><a href="https://example.com">Example label</a> ... <a href="https://example2.com">Example label 2</a></p>';
+        $this->assertSame(0, $instance::getInaccessibleUrlLinksFromContent($content));
+
+        // Test content with multiple links and invalid text content
+        $content = '<p><a href="https://example.com">https://example.com</a> ... <a href="https://example2.com">Example label 2</a></p>';
+        $this->assertSame(1, $instance::getInaccessibleUrlLinksFromContent($content));
+
+        // Test long content with multiple email links
+        $content = '<p>Contact us at <a href="https://example.com">https://example.com</a> ' .
+            'and <a href="https://example2.com">https://example2.com</a> ' .
+            'and <a href="https://example3.com">Example label 3</a> </p>';
+        $this->assertSame(2, $instance::getInaccessibleUrlLinksFromContent($content));
+
+        // A URL at the start of a paragraph should not be counted
+        $content = '<p>https://example.com is a link.</p>';
+        $this->assertSame(0, $instance::getInaccessibleUrlLinksFromContent($content));
+    }
+}

--- a/spec/Unit/_bootstrap.php
+++ b/spec/Unit/_bootstrap.php
@@ -18,5 +18,6 @@ require_once $theme_root_dir . '/inc/content-quality/issues/email-text.php';
 require_once $theme_root_dir . '/inc/content-quality/issues/empty-heading.php';
 require_once $theme_root_dir . '/inc/content-quality/issues/incomplete-thead.php';
 require_once $theme_root_dir . '/inc/content-quality/issues/thead.php';
+require_once $theme_root_dir . '/inc/content-quality/issues/url-text.php';
 require_once $theme_root_dir . '/inc/documents/permalinks.php';
 require_once $theme_root_dir . '/inc/post-meta/post-meta.php';


### PR DESCRIPTION
This PR adds an additional filter to the content quality framework.

It identifies pages where link text uses raw URLs. e.g. `<a href="https://demo.justice.gov.uk/courts/procedure-rules/civil/rules/part04">https://demo.justice.gov.uk/courts/procedure-rules/civil/rules/part04</a>`

HowTo Admin docs have been updated accordingly.