### PR TITLE
CDPT-2941 Update `sass`, remove deprecated `@import` and fix duplicated `.icon` blocks in css.

### DIFF
--- a/public/app/frontend/base.scss
+++ b/public/app/frontend/base.scss
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-@import "./style.scss";
+@use "style";
 
 html {
     font-size: 16px;
@@ -9,32 +9,32 @@ html, body {
 }
 
 body, p {
-    @include body;
+    @include style.body;
     margin: 0;
 }
 
 h1, .h1 {
-    @include h1;
+    @include style.h1;
 }
 
 h2, .h2 {
-    @include h2;
+    @include style.h2;
 }
 
 h3, .h3 {
-    @include h3;
+    @include style.h3;
 }
 
 h4, .h4 {
-    @include h4;
+    @include style.h4;
 }
 
 h5, .h5 {
-    @include h5;
+    @include style.h5;
 }
 
 h6, .h6 {
-    @include h6;
+    @include style.h6;
 }
 
 ul, ol {
@@ -45,5 +45,7 @@ ul, ol {
 }
 
 .visually-hidden {
-    @include visually-hidden;
+    @include style.visually-hidden;
 }
+
+@include style.icons;

--- a/public/app/frontend/package-lock.json
+++ b/public/app/frontend/package-lock.json
@@ -37,7 +37,7 @@
         "postcss-css-variables": "^0.19.0",
         "postcss-inline-svg": "^6.0.0",
         "postcss-loader": "^8.1.1",
-        "sass": "^1.77.6",
+        "sass": "^1.91.0",
         "sass-loader": "^14.2.1",
         "storybook": "^8.1.10",
         "stylelint": "^16.6.1",
@@ -2150,6 +2150,316 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
+      "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^1.0.3",
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.5",
+        "node-addon-api": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.1",
+        "@parcel/watcher-darwin-arm64": "2.5.1",
+        "@parcel/watcher-darwin-x64": "2.5.1",
+        "@parcel/watcher-freebsd-x64": "2.5.1",
+        "@parcel/watcher-linux-arm-glibc": "2.5.1",
+        "@parcel/watcher-linux-arm-musl": "2.5.1",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.1",
+        "@parcel/watcher-linux-arm64-musl": "2.5.1",
+        "@parcel/watcher-linux-x64-glibc": "2.5.1",
+        "@parcel/watcher-linux-x64-musl": "2.5.1",
+        "@parcel/watcher-win32-arm64": "2.5.1",
+        "@parcel/watcher-win32-ia32": "2.5.1",
+        "@parcel/watcher-win32-x64": "2.5.1"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
+      "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
+      "integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
+      "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
+      "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
+      "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
+      "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
+      "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
+      "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
+      "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
+      "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
+      "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
+      "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
+      "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/@sideway/address": {
@@ -5924,6 +6234,20 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -7975,10 +8299,11 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
-      "integrity": "sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ==",
-      "dev": true
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
+      "integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -11130,6 +11455,14 @@
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
       "dev": true
     },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -13003,13 +13336,14 @@
       "dev": true
     },
     "node_modules/sass": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
-      "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
+      "version": "1.91.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.91.0.tgz",
+      "integrity": "sha512-aFOZHGf+ur+bp1bCHZ+u8otKGh77ZtmFyXDo4tlYvT7PWql41Kwd8wdkPqhhT+h2879IVblcHFglIMofsFd1EA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "chokidar": ">=3.0.0 <4.0.0",
-        "immutable": "^4.0.0",
+        "chokidar": "^4.0.0",
+        "immutable": "^5.0.2",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
       "bin": {
@@ -13017,6 +13351,9 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
       }
     },
     "node_modules/sass-loader": {
@@ -13057,6 +13394,36 @@
         "webpack": {
           "optional": true
         }
+      }
+    },
+    "node_modules/sass/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/sass/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/scheduler": {

--- a/public/app/frontend/package.json
+++ b/public/app/frontend/package.json
@@ -35,7 +35,7 @@
     "postcss-css-variables": "^0.19.0",
     "postcss-inline-svg": "^6.0.0",
     "postcss-loader": "^8.1.1",
-    "sass": "^1.77.6",
+    "sass": "^1.91.0",
     "sass-loader": "^14.2.1",
     "storybook": "^8.1.10",
     "stylelint": "^16.6.1",

--- a/public/app/frontend/src/components/.template/template.scss
+++ b/public/app/frontend/src/components/.template/template.scss
@@ -1,4 +1,4 @@
-@import '../../../style';
+@use '../../../style';
 
 .template {
     background-color: var(--justice-primary-grey);

--- a/public/app/frontend/src/components/breadcrumbs/breadcrumbs.scss
+++ b/public/app/frontend/src/components/breadcrumbs/breadcrumbs.scss
@@ -1,4 +1,4 @@
-@import '../../../style';
+@use '../../../style';
 
 .breadcrumbs {
     &__list {
@@ -10,13 +10,13 @@
 
     &__item {
         a {
-            @include link;
+            @include style.link;
         }
 
         &:not(&:last-child) {
             &::after {
-                @include spacing('margin', 1, 'left');
-                @include spacing('margin', 1, 'right');
+                @include style.spacing('margin', 1, 'left');
+                @include style.spacing('margin', 1, 'right');
 
                 content: '\00BB';
                 color: var(--justice-primary-grey);

--- a/public/app/frontend/src/components/button/button.scss
+++ b/public/app/frontend/src/components/button/button.scss
@@ -1,15 +1,15 @@
-@import '../../../style';
+@use '../../../style';
 
 .button {
     &--primary {
-        @include button('primary');
+        @include style.button('primary');
     }
 
     &--dark {
-        @include button('dark');
+        @include style.button('dark');
     }
 
     &--light {
-        @include button('light');
+        @include style.button('light');
     }
 }

--- a/public/app/frontend/src/components/file-download/file-download.scss
+++ b/public/app/frontend/src/components/file-download/file-download.scss
@@ -1,13 +1,13 @@
-@import '../../../style';
+@use '../../../style';
 
 .file-download {
-    @include link;
+    @include style.link;
 
     // Keep the icon next to the text
     white-space: nowrap;
 
     &__icon {
-        @include spacing('margin', 1, 'right');
+        @include style.spacing('margin', 1, 'right');
         // Override the default icon styles
         display: inline-flex!important;
         position: relative;

--- a/public/app/frontend/src/components/footer/footer.scss
+++ b/public/app/frontend/src/components/footer/footer.scss
@@ -1,16 +1,16 @@
-@import '../../../style';
+@use '../../../style';
 
 .footer {
-    @include spacing('padding', 4, 'top');
+    @include style.spacing('padding', 4, 'top');
 
     background-color: var(--justice-primary-black);
 
     &__container {
-        @include container;
+        @include style.container;
 
         display: flex;
         flex-direction: column;
-        @media screen and (min-width: $justice-lg) {
+        @media screen and (min-width: style.$justice-lg) {
             justify-content: space-between;
         }
     }
@@ -19,8 +19,8 @@
         display: flex;
         flex-direction: column;
         width: 100%;
-        @include spacing('padding', 4, 'bottom');
-        @media screen and (min-width: $justice-lg) {
+        @include style.spacing('padding', 4, 'bottom');
+        @media screen and (min-width: style.$justice-lg) {
             flex-direction: row;
             margin-left: -0.625rem;
         }
@@ -28,38 +28,38 @@
 
     &__link {
         a {
-            @include link('light', 'menu');
-            @include spacing('padding', 2, 'top');
-            @include spacing('padding', 2, 'bottom');
+            @include style.link('light', 'menu');
+            @include style.spacing('padding', 2, 'top');
+            @include style.spacing('padding', 2, 'bottom');
 
             display: block;
-            @media screen and (min-width: $justice-lg) {
-                @include spacing('padding', 1, 'top');
-                @include spacing('padding', 1, 'bottom');
-                @include spacing('padding', 2, 'left');
-                @include spacing('padding', 2, 'right');
+            @media screen and (min-width: style.$justice-lg) {
+                @include style.spacing('padding', 1, 'top');
+                @include style.spacing('padding', 1, 'bottom');
+                @include style.spacing('padding', 2, 'left');
+                @include style.spacing('padding', 2, 'right');
             }
         }
     }
 
     &__details {
-        @include body;
-        @include spacing('padding', 2, 'top');
-        @include spacing('padding', 4, 'bottom');
+        @include style.body;
+        @include style.spacing('padding', 2, 'top');
+        @include style.spacing('padding', 4, 'bottom');
 
         border-top: 1px solid var(--justice-border);
         color: var(--justice-primary-white);
     }
 
     &__heading {
-        @include h3;
+        @include style.h3;
 
         font-weight: var(--heading-font-normal);
         color: var(--justice-secondary-light-blue);
     }
 
     &__gov {
-        @include focus-outline;
+        @include style.focus-outline;
 
         color: transparent;
         display: block;
@@ -67,7 +67,7 @@
     }
 
     &__logo {
-        @include spacing('margin', 4, 'top');
+        @include style.spacing('margin', 4, 'top');
 
         background-image: url('../../assets/govuk-logo-2.png');
         background-repeat: no-repeat;
@@ -77,12 +77,12 @@
     }
 
     &__content {
-        @include spacing('margin', 4, 'top');
+        @include style.spacing('margin', 4, 'top');
 
         color: var(--justice-primary-white);
 
         a {
-            @include link('light');
+            @include style.link('light');
 
             text-decoration: underline;
 
@@ -93,8 +93,8 @@
     }
 
     &__copyright {
-        @include spacing('padding', 2, 'top');
-        @include spacing('padding', 4, 'bottom');
+        @include style.spacing('padding', 2, 'top');
+        @include style.spacing('padding', 4, 'bottom');
 
         color: var(--justice-primary-white);
         display: flex;

--- a/public/app/frontend/src/components/header/header.scss
+++ b/public/app/frontend/src/components/header/header.scss
@@ -1,17 +1,17 @@
-@import '../../../style';
+@use '../../../style';
 
 .header {
-    @include spacing('padding', 2, 'top');
+    @include style.spacing('padding', 2, 'top');
 
     background-color: var(--justice-primary-black);
 
     &__container {
-        @include container;
+        @include style.container;
 
         display: flex;
         flex-direction: column;
-        @media screen and (min-width: $justice-lg) {
-            @include spacing('margin', 1, 'bottom');
+        @media screen and (min-width: style.$justice-lg) {
+            @include style.spacing('margin', 1, 'bottom');
 
             flex-direction: row;
             justify-content: space-between;
@@ -20,8 +20,8 @@
     }
 
     &__home {
-        @include focus-outline;
-        @include spacing('margin', 3, 'bottom');
+        @include style.focus-outline;
+        @include style.spacing('margin', 3, 'bottom');
 
         color: transparent;
     }
@@ -37,7 +37,7 @@
     &__logo,
     &__logotype {
         margin-right: 0.075rem;
-        @media screen and (min-width: $justice-md) {
+        @media screen and (min-width: style.$justice-md) {
             margin-right: 0.1rem;
         }
         background-repeat: no-repeat;
@@ -48,7 +48,7 @@
         width: 3rem;
         height: 3rem;
 
-        @media screen and (min-width: $justice-md) {
+        @media screen and (min-width: style.$justice-md) {
             width: 3.75rem;
             height: 3.75rem;
         }
@@ -61,7 +61,7 @@
         height: 2.15625rem;
         width: 6.65625rem;
         
-        @media screen and (min-width: $justice-md) {
+        @media screen and (min-width: style.$justice-md) {
             margin-top: 0.1rem;
             height: 2.875rem;
             width: 8.875rem; // (306 / 100) * 2.875
@@ -77,15 +77,15 @@
     }
 
     &__search {
-        @include spacing('margin', 1, 'bottom');
+        @include style.spacing('margin', 1, 'bottom');
 
-        @media screen and (min-width: $justice-lg) {
+        @media screen and (min-width: style.$justice-lg) {
             margin-bottom: 0;
         }
 
         input[type='text'] {
             width: 100%;
-            @media screen and (min-width: $justice-lg) {
+            @media screen and (min-width: style.$justice-lg) {
                 width: 15rem;
             }
         }

--- a/public/app/frontend/src/components/hero/hero.scss
+++ b/public/app/frontend/src/components/hero/hero.scss
@@ -1,11 +1,11 @@
-@import '../../../style';
+@use '../../../style';
 
 .hero {
     &__breadcrumbs {
-        @include spacing('margin', 4, 'bottom');
+        @include style.spacing('margin', 4, 'bottom');
     }
 
     &__title {
-        @include spacing('margin', 0, 'top');
+        @include style.spacing('margin', 0, 'top');
     }
 }

--- a/public/app/frontend/src/components/horizontal-rule/horizontal-rule.scss
+++ b/public/app/frontend/src/components/horizontal-rule/horizontal-rule.scss
@@ -1,16 +1,16 @@
-@import '../../../style';
+@use '../../../style';
 
 .horizontal-rule {
     display: none;
-    @media screen and (min-width: $justice-lg) {
+    @media screen and (min-width: style.$justice-lg) {
         display: block;
 
         &:not(&--full-width) {
-            @include container;
+            @include style.container;
         }
 
         &__hr {
-            @include spacing('margin', 8, 'top');
+            @include style.spacing('margin', 8, 'top');
 
             margin-bottom: 0;
             width: 100%;

--- a/public/app/frontend/src/components/image-with-text/image-with-text.scss
+++ b/public/app/frontend/src/components/image-with-text/image-with-text.scss
@@ -1,10 +1,10 @@
-@import '../../../style';
+@use '../../../style';
 
 .image-with-text {
     display: flex;
     flex-direction: column;
     width: 100%;
-    @media screen and (min-width: $justice-md) {
+    @media screen and (min-width: style.$justice-md) {
         &--right {
             flex-direction: row-reverse;
         }
@@ -20,7 +20,7 @@
         .image {
             width: 100%;
             height: 12rem;
-            @media screen and (min-width: $justice-md) {
+            @media screen and (min-width: style.$justice-md) {
                 height: 100%;
                 max-height: 17rem;
             }
@@ -29,9 +29,9 @@
 
     &__content {
         flex-basis: 40%;
-        @media screen and (min-width: $justice-md) {
-            @include spacing('padding', 6, 'left');
-            @include spacing('padding', 6, 'right');
+        @media screen and (min-width: style.$justice-md) {
+            @include style.spacing('padding', 6, 'left');
+            @include style.spacing('padding', 6, 'right');
 
             margin-top: 0;
         }
@@ -39,14 +39,14 @@
 
     &__title {
         > :is(h1, h2, h3, h4, h5, h6) {
-            @include h2;
-            @media screen and (min-width: $justice-md) {
+            @include style.h2;
+            @media screen and (min-width: style.$justice-md) {
                 margin-top: 0;
             }
         }
 
         a {
-            @include link;
+            @include style.link;
 
             font-family: inherit;
             font-size: inherit;
@@ -54,11 +54,11 @@
     }
 
     .rich-text {
-        @include spacing('margin', 4, 'top');
+        @include style.spacing('margin', 4, 'top');
 
         p,
         a {
-            @include h6;
+            @include style.h6;
 
             font-family: var(--justice-body-font);
         }

--- a/public/app/frontend/src/components/image/image.scss
+++ b/public/app/frontend/src/components/image/image.scss
@@ -1,4 +1,4 @@
-@import '../../../style';
+@use '../../../style';
 
 .image {
     img {
@@ -6,7 +6,7 @@
         height: 100%;
         object-fit: cover;
         object-position: top;
-        @media screen and (min-width: $justice-md) {
+        @media screen and (min-width: style.$justice-md) {
             object-position: center;
         }
     }

--- a/public/app/frontend/src/components/link/link.scss
+++ b/public/app/frontend/src/components/link/link.scss
@@ -1,5 +1,5 @@
-@import '../../../style';
+@use '../../../style';
 
 .link {
-    @include link;
+    @include style.link;
 }

--- a/public/app/frontend/src/components/navigation-main/navigation-main.scss
+++ b/public/app/frontend/src/components/navigation-main/navigation-main.scss
@@ -1,22 +1,22 @@
 @use 'sass:map';
-@import '../../../style';
+@use '../../../style';
 
 .navigation-main {
     background: var(--justice-primary-black);
 
     &__container {
-        @include container;
+        @include style.container;
     }
 
     &__list {
         display: flex;
         flex-direction: column;
         width: 100%;
-        @media screen and (min-width: $justice-lg) {
+        @media screen and (min-width: style.$justice-lg) {
             flex-direction: row;
 
             // Have a negative margin equal to the padding spacing so the text is visually inline with the container element but so the focus highlight still has padding
-            margin-left: calc(map.get($spacing-units-desktop, 2) * -1);
+            margin-left: calc(map.get(style.$spacing-units-desktop, 2) * -1);
         }
     }
 
@@ -34,21 +34,21 @@
         }
 
         a {
-            @include link('light', 'menu');
-            @include spacing('padding', 2, 'top');
-            @include spacing('padding', 2, 'bottom');
+            @include style.link('light', 'menu');
+            @include style.spacing('padding', 2, 'top');
+            @include style.spacing('padding', 2, 'bottom');
 
             display: block;
             font-family: var(--heading-font);
-            @media screen and (min-width: $justice-lg) {
-                @include spacing('padding', 1, 'top');
-                @include spacing('padding', 1, 'bottom');
-                @include spacing('padding', 2, 'left');
-                @include spacing('padding', 2, 'right');
+            @media screen and (min-width: style.$justice-lg) {
+                @include style.spacing('padding', 1, 'top');
+                @include style.spacing('padding', 1, 'bottom');
+                @include style.spacing('padding', 2, 'left');
+                @include style.spacing('padding', 2, 'right');
             }
         }
 
-        @media screen and (min-width: $justice-lg) {
+        @media screen and (min-width: style.$justice-lg) {
             border-top: none;
             border-left: 1px var(--justice-border) solid;
 

--- a/public/app/frontend/src/components/navigation-secondary/navigation-secondary.scss
+++ b/public/app/frontend/src/components/navigation-secondary/navigation-secondary.scss
@@ -1,19 +1,19 @@
 @use 'sass:map';
-@import '../../../style';
+@use '../../../style';
 
 .navigation-secondary {
     $this: &;
 
     display: flex;
     flex-direction: column;
-    width: calc(100% + ($gutter-mobile * 2));
+    width: calc(100% + (style.$gutter-mobile * 2));
     height: fit-content;
-    margin-left: calc($gutter-mobile * -1);
-    margin-right: calc($gutter-mobile * -1);
+    margin-left: calc(style.$gutter-mobile * -1);
+    margin-right: calc(style.$gutter-mobile * -1);
     background-color: var(--justice-primary-black);
 
-    @media screen and (min-width: $justice-lg) {
-        @include spacing('margin', 8, 'top');
+    @media screen and (min-width: style.$justice-lg) {
+        @include style.spacing('margin', 8, 'top');
 
         width: 100%;
         margin: 0;
@@ -22,17 +22,17 @@
 
     &__skip-to-article {
         &:not(:active, :focus-within) {
-            @include visually-hidden;
+            @include style.visually-hidden;
         }
     }
 
     &__heading {
         display: none;
-        @media screen and (min-width: $justice-lg) {
-            @include panel-title;
-            @include spacing('padding', 2);
-            @include spacing('padding', 3, 'top');
-            @include spacing('padding', 3, 'bottom');
+        @media screen and (min-width: style.$justice-lg) {
+            @include style.panel-title;
+            @include style.spacing('padding', 2);
+            @include style.spacing('padding', 3, 'top');
+            @include style.spacing('padding', 3, 'bottom');
 
             display: flex;
             align-items: center;
@@ -43,7 +43,7 @@
     }
 
     &__link {
-        @include link('light', 'menu');
+        @include style.link('light', 'menu');
 
         display: flex;
         align-items: center;
@@ -70,8 +70,8 @@
             }
         }
 
-        @media screen and (min-width: $justice-lg) {
-            @include link;
+        @media screen and (min-width: style.$justice-lg) {
+            @include style.link;
 
             &:visited {
                 color: var(--justice-link);
@@ -99,11 +99,11 @@
     }
 
     &__button {
-        @include arrow-button('light');
-        @include spacing('padding', 2);
+        @include style.arrow-button('light');
+        @include style.spacing('padding', 2);
 
-        padding-left: $gutter-mobile;
-        padding-right: $gutter-mobile;
+        padding-left: style.$gutter-mobile;
+        padding-right: style.$gutter-mobile;
 
         // The very first expand button - shown only on mobile screens.
         &--nav {
@@ -113,9 +113,9 @@
             text-transform: capitalize;
 
             &::after {
-                @include spacing('margin', 2, 'left');
+                @include style.spacing('margin', 2, 'left');
             }
-            @media screen and (min-width: $justice-lg) {
+            @media screen and (min-width: style.$justice-lg) {
                 display: none;
             }
         }
@@ -130,8 +130,8 @@
             // This width is 2 * $gutter-mobile, plus 14px for the arrow button.
             width: 2.875rem;
 
-            @media screen and (min-width: $justice-lg) {
-                @include arrow-button('dark');
+            @media screen and (min-width: style.$justice-lg) {
+                @include style.arrow-button('dark');
 
                 // Set width here to override the 100% width that is
                 // applied by the `arrow-button` mixin.
@@ -139,14 +139,14 @@
 
                 // Use important on padding here, to get a higher specificity
                 // than the padding applied by the `arrow-button` mixin.
-                padding-left: $gutter-mobile !important;
-                padding-right: $gutter-mobile !important;
+                padding-left: style.$gutter-mobile !important;
+                padding-right: style.$gutter-mobile !important;
             }
         }
     }
 
     &__nav {
-        @include spacing('padding', 1, 'bottom');
+        @include style.spacing('padding', 1, 'bottom');
 
         display: none;
 
@@ -155,7 +155,7 @@
             flex-direction: column;
             width: 100%;
         }
-        @media screen and (min-width: $justice-lg) {
+        @media screen and (min-width: style.$justice-lg) {
             display: flex;
             flex-direction: column;
             width: 100%;
@@ -176,15 +176,15 @@
     }
 
     &__list-item-wrapper {
-        @include spacing('padding', 2);
+        @include style.spacing('padding', 2);
 
         position: relative;
         display: flex;
         justify-content: space-between;
-        padding-left: $gutter-mobile;
-        padding-right: $gutter-mobile;
-        @media screen and (min-width: $justice-lg) {
-            @include spacing('padding', 2);
+        padding-left: style.$gutter-mobile;
+        padding-right: style.$gutter-mobile;
+        @media screen and (min-width: style.$justice-lg) {
+            @include style.spacing('padding', 2);
 
             // Create an after element to be used for the active state background.
             // Use a pseudo-element to aloww for an offset when we have a sublist toggle button.
@@ -217,7 +217,7 @@
                     text-decoration: none;
                 }
             }
-            @media screen and (min-width: $justice-lg) {
+            @media screen and (min-width: style.$justice-lg) {
                 > #{$this}__list-item-wrapper::after {
                     background-color: var(--justice-primary-grey);
                 }
@@ -239,7 +239,7 @@
         &--level-1,
         &--level-2 {
             background-color: var(--justice-primary-black);
-            @media screen and (min-width: $justice-lg) {
+            @media screen and (min-width: style.$justice-lg) {
                 background-color: var(--justice-secondary-grey-blue);
             }
         }
@@ -247,35 +247,35 @@
         &--level-1 {
             #{$this}__link,
             #{$this}__button-text {
-                @include spacing('padding', 2, 'left');
+                @include style.spacing('padding', 2, 'left');
             }
         }
 
         &--level-2 {
             #{$this}__link,
             #{$this}__button-text {
-                @include spacing('padding', 6, 'left');
+                @include style.spacing('padding', 6, 'left');
             }
         }
 
         &--level-3 {
             #{$this}__link,
             #{$this}__button-text {
-                @include spacing('padding', 7, 'left');
+                @include style.spacing('padding', 7, 'left');
             }
         }
 
         &--level-4 {
             #{$this}__link,
             #{$this}__button-text {
-                @include spacing('padding', 8, 'left');
+                @include style.spacing('padding', 8, 'left');
             }
         }
     }
 
     &__show-all {
         background-color: var(--justice-primary-black);
-        @media screen and (min-width: $justice-lg) {
+        @media screen and (min-width: style.$justice-lg) {
             background-color: var(--justice-secondary-grey-blue);
         }
     }

--- a/public/app/frontend/src/components/navigation-sections/navigation-sections.scss
+++ b/public/app/frontend/src/components/navigation-sections/navigation-sections.scss
@@ -1,8 +1,8 @@
 @use 'sass:map';
-@import '../../../style';
+@use '../../../style';
 
 .navigation-sections {
-    @include spacing('margin', 4, 'top');
+    @include style.spacing('margin', 4, 'top');
 
     display: block;
     max-width: 100%;
@@ -12,13 +12,13 @@
         grid-template-columns: repeat(auto-fit, minmax(30%, 1fr));
         align-items: baseline;
         gap: 0.5rem;
-        @media screen and (min-width: $justice-md) {
+        @media screen and (min-width: style.$justice-md) {
             grid-template-columns: repeat(auto-fit, minmax(16%, 1fr));
         }
     }
 
     &__list-item {
-        @include spacing('padding', 1);
+        @include style.spacing('padding', 1);
 
         position: relative;
         display: flex;
@@ -26,7 +26,7 @@
         border: 1px solid var(--justice-border);
 
         a {
-            @include link;
+            @include style.link;
 
             &::after {
                 content: '';

--- a/public/app/frontend/src/components/pagination/pagination.scss
+++ b/public/app/frontend/src/components/pagination/pagination.scss
@@ -1,16 +1,16 @@
-@import '../../../style';
+@use '../../../style';
 
 .pagination {
     $this: &;
 
-    @include spacing('margin', 8, 'top');
+    @include style.spacing('margin', 8, 'top');
 
     display: flex;
     justify-content: center;
 
     &__list {
-        @include spacing('margin', 9, 'left');
-        @include spacing('margin', 9, 'right');
+        @include style.spacing('margin', 9, 'left');
+        @include style.spacing('margin', 9, 'right');
 
         display: flex;
         flex-direction: row;
@@ -18,9 +18,9 @@
     }
 
     &__link {
-        @include link;
-        @include spacing('padding', 1, 'left');
-        @include spacing('padding', 1, 'right');
+        @include style.link;
+        @include style.spacing('padding', 1, 'left');
+        @include style.spacing('padding', 1, 'right');
 
         display: flex;
         justify-content: center;
@@ -29,19 +29,19 @@
 
         &--previous {
             #{$this}__link-text {
-                @include spacing('padding', 1, 'left');
+                @include style.spacing('padding', 1, 'left');
             }
         }
 
         &--next {
             #{$this}__link-text {
-                @include spacing('padding', 1, 'right');
+                @include style.spacing('padding', 1, 'right');
             }
         }
     }
 
     &__link.disabled {
-        @include disabled;
+        @include style.disabled;
 
         color: var(--justice-primary-black);
 
@@ -51,8 +51,8 @@
     }
 
     &__link-text {
-        @media screen and (width <= calc($justice-lg - 1px)) {
-            @include visually-hidden;
+        @media screen and (width <= calc(style.$justice-lg - 1px)) {
+            @include style.visually-hidden;
         }
     }
 }

--- a/public/app/frontend/src/components/rich-text/rich-text.scss
+++ b/public/app/frontend/src/components/rich-text/rich-text.scss
@@ -1,5 +1,5 @@
-@import '../../../style';
+@use '../../../style';
 
 .rich-text {
-    @include rich-text;
+    @include style.rich-text;
 }

--- a/public/app/frontend/src/components/search-bar-block/search-bar-block.scss
+++ b/public/app/frontend/src/components/search-bar-block/search-bar-block.scss
@@ -1,11 +1,11 @@
-@import '../../../style';
+@use '../../../style';
 
 .search-bar-block {
     display: flex;
     flex-direction: column;
 
     &__wrapper {
-        @include spacing('padding', 2);
+        @include style.spacing('padding', 2);
 
         display: flex;
         background-color: var(--justice-primary-grey);
@@ -16,39 +16,39 @@
 
     &__search {
         width: 100%;
-        @media screen and (min-width: $justice-lg) {
+        @media screen and (min-width: style.$justice-lg) {
             width: 70%;
         }
     }
 
     &__results {
-        @include spacing('margin', 1, 'top');
+        @include style.spacing('margin', 1, 'top');
 
         display: flex;
         justify-content: end;
         width: 100%;
-        @media screen and (min-width: $justice-lg) {
+        @media screen and (min-width: style.$justice-lg) {
             margin-top: 0;
             width: 30%;
         }
     }
 
     &__did-you-mean {
-        @include spacing('margin', 4, 'top');
+        @include style.spacing('margin', 4, 'top');
 
         display: block;
         width: 100%;
         a {
-            @include link();
+            @include style.link();
         }
     }
 
     &__results-text {
-        @include body;
+        @include style.body;
     }
 
     &__filter.disabled {
-        @include disabled;
+        @include style.disabled;
 
         color: var(--justice-primary-black);
 
@@ -58,23 +58,23 @@
     }
 
     &__filters-wrapper {
-        @include spacing('padding', 2, 'top');
+        @include style.spacing('padding', 2, 'top');
 
         display: flex;
         justify-content: space-between;
-        @media screen and (min-width: $justice-lg) {
+        @media screen and (min-width: style.$justice-lg) {
             justify-content: start;
         }
     }
 
     &__filters {
-        @include spacing('padding', 2, 'left');
+        @include style.spacing('padding', 2, 'left');
     }
 
     &__filter {
-        @include spacing('padding', 1, 'right');
-        @include spacing('padding', 1, 'left');
-        @include link;
+        @include style.spacing('padding', 1, 'right');
+        @include style.spacing('padding', 1, 'left');
+        @include style.link;
 
         border-left: 1px var(--justice-border) solid;
 

--- a/public/app/frontend/src/components/search-result-card/search-result-card.scss
+++ b/public/app/frontend/src/components/search-result-card/search-result-card.scss
@@ -1,10 +1,10 @@
-@import '../../../style';
+@use '../../../style';
 
 .search-result-card {
     margin-top: 0;
 
     &__title {
-        @include h3;
+        @include style.h3;
 
         margin-top: 0;
 
@@ -21,20 +21,20 @@
             font-family: inherit;
             word-break: break-word;
         }
-        @media screen and (min-width: $justice-lg) {
+        @media screen and (min-width: style.$justice-lg) {
             margin-top: 0;
         }
     }
 
     &__description {
-        @include spacing('margin', 1, 'top');
+        @include style.spacing('margin', 1, 'top');
 
         overflow-wrap: break-word;
     }
 
     &__url {
-        @include spacing('margin', 1, 'top');
-        @include small;
+        @include style.spacing('margin', 1, 'top');
+        @include style.small;
 
         overflow-wrap: break-word;
     }

--- a/public/app/frontend/src/components/search-result-list/search-result-list.scss
+++ b/public/app/frontend/src/components/search-result-list/search-result-list.scss
@@ -1,9 +1,9 @@
-@import '../../../style';
+@use '../../../style';
 
 .search-result-list {
     &__element {
-        @include spacing('padding', 6, 'top');
-        @include spacing('padding', 6, 'bottom');
+        @include style.spacing('padding', 6, 'top');
+        @include style.spacing('padding', 6, 'bottom');
 
         border-bottom: 1px solid var(--justice-border);
 

--- a/public/app/frontend/src/components/selection-input/selection-input.scss
+++ b/public/app/frontend/src/components/selection-input/selection-input.scss
@@ -1,4 +1,4 @@
-@import '../../../style';
+@use '../../../style';
 
 .selection-input {
     $this: &;
@@ -6,7 +6,7 @@
     position: relative;
 
     &__legend {
-        @include h3;
+        @include style.h3;
     }
 
     &__fieldset {
@@ -16,12 +16,12 @@
     }
 
     &__options {
-        @include spacing('margin', 2, 'top');
+        @include style.spacing('margin', 2, 'top');
 
         display: flex;
         flex-direction: column;
         gap: 0.5rem;
-        @media screen and (min-width: $justice-lg) {
+        @media screen and (min-width: style.$justice-lg) {
             flex-direction: row;
 
             &--vertical {
@@ -145,12 +145,12 @@
     }
 
     &__hint {
-        @include small;
-        @include spacing('margin', 1, 'top');
+        @include style.small;
+        @include style.spacing('margin', 1, 'top');
     }
 
     &__error-text {
-        @include spacing('margin', 1, 'bottom');
+        @include style.spacing('margin', 1, 'bottom');
 
         color: var(--justice-error);
         font-weight: var(--body-font-bold);
@@ -175,6 +175,6 @@
     }
 
     &--error {
-        @include error-highlight;
+        @include style.error-highlight;
     }
 }

--- a/public/app/frontend/src/components/sidebar-block/sidebar-block.scss
+++ b/public/app/frontend/src/components/sidebar-block/sidebar-block.scss
@@ -1,4 +1,4 @@
-@import '../../../style';
+@use '../../../style';
 
 .sidebar-block {
     width: 100%;
@@ -14,7 +14,7 @@
     }
 
     &__description {
-        @include spacing('margin', 2, 'bottom');
+        @include style.spacing('margin', 2, 'bottom');
     }
 
     &__heading-wrapper {
@@ -24,7 +24,7 @@
     }
 
     &__heading {
-        @include panel-title;
+        @include style.panel-title;
 
         display: flex;
         justify-content: space-between;
@@ -36,10 +36,10 @@
 
     &__heading-text {
         display: none;
-        @media screen and (min-width: $justice-lg) {
-            @include spacing('padding', 2);
-            @include spacing('padding', 3, 'top');
-            @include spacing('padding', 3, 'bottom');
+        @media screen and (min-width: style.$justice-lg) {
+            @include style.spacing('padding', 2);
+            @include style.spacing('padding', 3, 'top');
+            @include style.spacing('padding', 3, 'bottom');
 
             display: flex;
             justify-content: space-between;
@@ -63,25 +63,25 @@
     }
 
     &__heading-button {
-        @include arrow-button('light');
-        @include panel-title;
+        @include style.arrow-button('light');
+        @include style.panel-title;
 
         margin: 0;
         color: var(--justice-primary-white);
-        @include spacing('padding', 2);
-        @include spacing('padding', 4, 'top');
-        @include spacing('padding', 4, 'bottom');
+        @include style.spacing('padding', 2);
+        @include style.spacing('padding', 4, 'top');
+        @include style.spacing('padding', 4, 'bottom');
 
         width: 100%;
-        @media screen and (min-width: $justice-lg) {
+        @media screen and (min-width: style.$justice-lg) {
             display: none;
         }
     }
 
     &__content {
-        @include spacing('padding', 2);
-        @include spacing('padding', 3, 'top');
-        @include spacing('padding', 3, 'bottom');
+        @include style.spacing('padding', 2);
+        @include style.spacing('padding', 3, 'top');
+        @include style.spacing('padding', 3, 'bottom');
 
         background-color: var(--justice-secondary-grey-blue);
         display: none;
@@ -89,18 +89,18 @@
         &--open {
             display: block;
         }
-        @media screen and (min-width: $justice-lg) {
+        @media screen and (min-width: style.$justice-lg) {
             display: block;
         }
     }
 
     &__list {
         > li {
-            @include spacing('padding', 1, 'top');
-            @include spacing('padding', 1, 'bottom');
+            @include style.spacing('padding', 1, 'top');
+            @include style.spacing('padding', 1, 'bottom');
 
             a {
-                @include link;
+                @include style.link;
             }
 
             &:first-child {
@@ -114,15 +114,15 @@
     }
 
     &__search-filter-field {
-        @include spacing('margin', 4, 'top');
+        @include style.spacing('margin', 4, 'top');
 
         &:first-child {
-            @include spacing('margin', 2, 'top');
+            @include style.spacing('margin', 2, 'top');
         }
     }
 
     &__search-filter-buttons {
-        @include spacing('margin', 6, 'top');
+        @include style.spacing('margin', 6, 'top');
 
         display: flex;
         justify-content: end;
@@ -131,13 +131,13 @@
 
     &__search-filter--disabled {
         .selection-input__legend {
-            @include disabled;
+            @include style.disabled;
         }
     }
 
     &__search-filter-no-query-hint {
-        @include spacing('margin', 2, 'top');
-        @include body;
+        @include style.spacing('margin', 2, 'top');
+        @include style.body;
     }
 
     .file-download {
@@ -150,7 +150,7 @@
     }
 
     .search-bar {
-        @include spacing('padding', 2, 'top');
+        @include style.spacing('padding', 2, 'top');
 
         input {
             padding-right: 0;

--- a/public/app/frontend/src/components/skip-link/skip-link.scss
+++ b/public/app/frontend/src/components/skip-link/skip-link.scss
@@ -1,16 +1,16 @@
-@import '../../../style';
+@use '../../../style';
 
 .skip-link {
-    @include spacing('padding', 4);
+    @include style.spacing('padding', 4);
 
     background-color: var(--gds-yellow);
     position: absolute;
 
     &:not(:active, :focus-within) {
-        @include visually-hidden;
+        @include style.visually-hidden;
     }
 
     a {
-        @include link('dark');
+        @include style.link('dark');
     }
 }

--- a/public/app/frontend/src/components/text-input-form/text-input-form.scss
+++ b/public/app/frontend/src/components/text-input-form/text-input-form.scss
@@ -1,4 +1,4 @@
-@import '../../../style';
+@use '../../../style';
 
 .text-input-form {
     display: flex;

--- a/public/app/frontend/src/components/text-input/text-input.scss
+++ b/public/app/frontend/src/components/text-input/text-input.scss
@@ -1,4 +1,4 @@
-@import '../../../style';
+@use '../../../style';
 
 .text-input {
     $this: &;
@@ -7,14 +7,14 @@
     align-items: center;
 
     &__label {
-        @include body;
-        @include spacing('margin', 2, 'right');
+        @include style.body;
+        @include style.spacing('margin', 2, 'right');
     }
 
     &__input {
-        @include body;
-        @include spacing('padding', 1);
-        @include focus-outline;
+        @include style.body;
+        @include style.spacing('padding', 1);
+        @include style.focus-outline;
 
         width: 100%;
         border: 2px solid var(--justice-border-input);
@@ -28,7 +28,7 @@
         #{$this}__label,
         #{$this}__input,
         #{$this}__wrapper {
-            @include disabled;
+            @include style.disabled;
         }
     }
 }

--- a/public/app/frontend/src/components/to-the-top/to-the-top.scss
+++ b/public/app/frontend/src/components/to-the-top/to-the-top.scss
@@ -1,8 +1,8 @@
-@import '../../../style';
+@use '../../../style';
 
 .to-the-top {
-    @include link;
-    @include spacing('margin', 4, 'top');
+    @include style.link;
+    @include style.spacing('margin', 4, 'top');
 
     display: flex;
     align-items: center;
@@ -13,13 +13,13 @@
     }
 
     &::after {
-        @include triangle('top', var(--justice-link), 0.5rem);
-        @include spacing('margin', 1, 'left');
+        @include style.triangle('top', var(--justice-link), 0.5rem);
+        @include style.spacing('margin', 1, 'left');
     }
 
     &:hover {
         &::after {
-            @include triangle('top', var(--justice-link-hover), 0.5rem);
+            @include style.triangle('top', var(--justice-link-hover), 0.5rem);
         }
 
         &:visited {
@@ -29,7 +29,7 @@
 
     &:focus-visible:not(:active, :hover) {
         &::after {
-            @include triangle('top', var(--gds-black), 0.5rem);
+            @include style.triangle('top', var(--gds-black), 0.5rem);
         }
     }
 }

--- a/public/app/frontend/src/components/updated-date/updated-date.scss
+++ b/public/app/frontend/src/components/updated-date/updated-date.scss
@@ -1,4 +1,4 @@
-@import '../../../style';
+@use '../../../style';
 
 .updated-date {
     width: 100%;

--- a/public/app/frontend/src/layouts/base/base.scss
+++ b/public/app/frontend/src/layouts/base/base.scss
@@ -1,4 +1,4 @@
-@import '../../../style';
+@use '../../../style';
 
 .page-wrapper {
     display: flex;
@@ -7,7 +7,7 @@
 }
 
 .footer-wrapper {
-    @include spacing('margin', 8, 'top');
+    @include style.spacing('margin', 8, 'top');
 
     flex: 1;
     background-color: var(--justice-primary-black);

--- a/public/app/frontend/src/layouts/one-sidebar/one-sidebar.scss
+++ b/public/app/frontend/src/layouts/one-sidebar/one-sidebar.scss
@@ -1,27 +1,27 @@
-@import '../../../style';
+@use '../../../style';
 
 .one-sidebar {
     $this: &;
-    @include container;
+    @include style.container;
 
     &__grid {
-        @include grid;
+        @include style.grid;
     }
 
     &__article,
     &__sidebar {
-        @include grid-row(1, 4);
+        @include style.grid-row(1, 4);
     }
 
     &__article-header {
         width: 100%;
 
         > * {
-            @include spacing('margin', 4, 'top');
+            @include style.spacing('margin', 4, 'top');
         }
 
         > :first-child {
-            @include spacing('margin', 8, 'top');
+            @include style.spacing('margin', 8, 'top');
         }
     }
 
@@ -29,55 +29,55 @@
         width: 100%;
 
         > * {
-            @include spacing('margin', 8, 'top');
+            @include style.spacing('margin', 8, 'top');
         }
 
         > .file-download {
-            @include spacing('margin', 4, 'top');
+            @include style.spacing('margin', 4, 'top');
         }
     }
 
     &__sidebar {
         display: none;
-        @media screen and (min-width: $justice-lg) {
+        @media screen and (min-width: style.$justice-lg) {
             > * {
-                @include spacing('margin', 6, 'top');
+                @include style.spacing('margin', 6, 'top');
             }
 
             > :first-child {
-                @include spacing('margin', 8, 'top');
+                @include style.spacing('margin', 8, 'top');
             }
         }
 
         &--mobile {
             display: flex;
-            @media screen and (min-width: $justice-lg) {
+            @media screen and (min-width: style.$justice-lg) {
                 display: none;
             }
         }
     }
 
     &--right {
-        @media screen and (min-width: $justice-lg) {
+        @media screen and (min-width: style.$justice-lg) {
             #{$this}__sidebar:not(#{$this}__sidebar--mobile) {
-                @include grid-row(10, 3);
+                @include style.grid-row(10, 3);
             }
             #{$this}__article {
-                @include grid-row(1, 7);
+                @include style.grid-row(1, 7);
                 &--homepage {
-                    @include grid-row(1, 9);
+                    @include style.grid-row(1, 9);
                 }
             }
         }
     }
 
     &--left {
-        @media screen and (min-width: $justice-lg) {
+        @media screen and (min-width: style.$justice-lg) {
             #{$this}__sidebar:not(#{$this}__sidebar--mobile) {
-                @include grid-row(1, 3);
+                @include style.grid-row(1, 3);
             }
             #{$this}__article {
-                @include grid-row(4, 9);
+                @include style.grid-row(4, 9);
             }
         }
     }

--- a/public/app/frontend/src/layouts/two-sidebars/two-sidebars.scss
+++ b/public/app/frontend/src/layouts/two-sidebars/two-sidebars.scss
@@ -1,18 +1,18 @@
-@import '../../../style';
+@use '../../../style';
 
 .two-sidebars {
     $this: &;
-    @include container;
+    @include style.container;
 
     &__grid {
-        @include grid;
+        @include style.grid;
     }
 
     &__article {
-        @include grid-row(1, 4);
+        @include style.grid-row(1, 4);
 
-        @media screen and (min-width: $justice-lg) {
-            @include grid-row(4, 6);
+        @media screen and (min-width: style.$justice-lg) {
+            @include style.grid-row(4, 6);
         }
     }
 
@@ -20,11 +20,11 @@
         width: 100%;
 
         > * {
-            @include spacing('margin', 4, 'top');
+            @include style.spacing('margin', 4, 'top');
         }
 
         > :first-child {
-            @include spacing('margin', 8, 'top');
+            @include style.spacing('margin', 8, 'top');
         }
     }
 
@@ -32,42 +32,42 @@
         width: 100%;
 
         > * {
-            @include spacing('margin', 8, 'top');
+            @include style.spacing('margin', 8, 'top');
         }
 
         > .file-download {
-            @include spacing('margin', 4, 'top');
+            @include style.spacing('margin', 4, 'top');
         }
     }
 
     &__sidebar {
-        @include grid-row(1, 4);
+        @include style.grid-row(1, 4);
 
         &--left {
-            @media screen and (min-width: $justice-lg) {
-                @include grid-row(1, 3);
+            @media screen and (min-width: style.$justice-lg) {
+                @include style.grid-row(1, 3);
             }
         }
 
         &--right {
             display: none;
-            @media screen and (min-width: $justice-lg) {
-                @include grid-row(10, 3);
+            @media screen and (min-width: style.$justice-lg) {
+                @include style.grid-row(10, 3);
             }
         }
 
         &--mobile {
             display: flex;
-            @media screen and (min-width: $justice-lg) {
+            @media screen and (min-width: style.$justice-lg) {
                 display: none;
             }
         }
 
         > *:not(.navigation-secondary) {
-            @include spacing('margin', 6, 'top');
-            @media screen and (min-width: $justice-lg) {
+            @include style.spacing('margin', 6, 'top');
+            @media screen and (min-width: style.$justice-lg) {
                 &:first-child {
-                    @include spacing('margin', 8, 'top');
+                    @include style.spacing('margin', 8, 'top');
                 }
             }
         }

--- a/public/app/frontend/style.scss
+++ b/public/app/frontend/style.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @use "sass:map";
 
 :root {
@@ -118,15 +119,15 @@ $spacing-units-desktop: (
 
 @mixin spacing($type: 'margin', $unit: 1, $direction: 'all') {
     @if ($direction != 'all') {
-        #{$type}-#{$direction}: map-get($spacing-units-mobile, $unit);
+        #{$type}-#{$direction}: map.get($spacing-units-mobile, $unit);
         @media screen and (min-width: $justice-lg) {
-            #{$type}-#{$direction}: map-get($spacing-units-desktop, $unit);
+            #{$type}-#{$direction}: map.get($spacing-units-desktop, $unit);
         }
     }
     @else {
-        #{$type}: map-get($spacing-units-mobile, $unit);
+        #{$type}: map.get($spacing-units-mobile, $unit);
         @media screen and (min-width: $justice-lg) {
-            #{$type}: map-get($spacing-units-desktop, $unit);
+            #{$type}: map.get($spacing-units-desktop, $unit);
         }
     }
 
@@ -135,7 +136,7 @@ $spacing-units-desktop: (
 // Headings https://design-system.service.gov.uk/styles/type-scale/
 // Use map-get instead of the spacing function here otherwise it's harder to override per component due to css specificity
 @mixin h1 {
-    margin-top: map-get($spacing-units-mobile, 8);
+    margin-top: map.get($spacing-units-mobile, 8);
     margin-bottom: 0;
     font-size: 2rem;
     line-height: 2.188rem;
@@ -146,14 +147,14 @@ $spacing-units-desktop: (
         @include caption('h1');
     }
     @media screen and (min-width: $justice-lg) {
-        margin-top: map-get($spacing-units-desktop, 8);
+        margin-top: map.get($spacing-units-desktop, 8);
         font-size: 3rem;
         line-height: 3.125rem;
     }
 }
 
 @mixin h2 {
-    margin-top: map-get($spacing-units-mobile, 6);
+    margin-top: map.get($spacing-units-mobile, 6);
     margin-bottom: 0;
     font-size: 1.688rem;
     line-height: 1.875rem;
@@ -164,14 +165,14 @@ $spacing-units-desktop: (
         @include caption('h2');
     }
     @media screen and (min-width: $justice-lg) {
-        margin-top: map-get($spacing-units-desktop, 6);
+        margin-top: map.get($spacing-units-desktop, 6);
         font-size: 2.25rem;
         line-height: 2.5rem;
     }
 }
 
 @mixin h3 {
-    margin-top: map-get($spacing-units-mobile, 4);
+    margin-top: map.get($spacing-units-mobile, 4);
     margin-bottom: 0;
     font-size: 1.313rem;
     line-height: 1.563rem;
@@ -182,14 +183,14 @@ $spacing-units-desktop: (
         @include caption('h3');
     }
     @media screen and (min-width: $justice-lg) {
-        margin-top: map-get($spacing-units-desktop, 4);
+        margin-top: map.get($spacing-units-desktop, 4);
         font-size: 1.625rem;
         line-height: 1.875rem;
     }
 }
 
 @mixin h4 {
-    margin-top: map-get($spacing-units-mobile, 4);
+    margin-top: map.get($spacing-units-mobile, 4);
     margin-bottom: 0;
     font-size: 1.25rem;
     line-height: 1.563rem;
@@ -197,14 +198,14 @@ $spacing-units-desktop: (
     font-weight: var(--heading-font-bold);
     color: var(--justice-primary-black);
     @media screen and (min-width: $justice-lg) {
-        margin-top: map-get($spacing-units-desktop, 4);
+        margin-top: map.get($spacing-units-desktop, 4);
         font-size: 1.375rem;
         line-height: 1.875rem;
     }
 }
 
 @mixin h5 {
-    margin-top: map-get($spacing-units-mobile, 4);
+    margin-top: map.get($spacing-units-mobile, 4);
     margin-bottom: 0;
     font-size: 1.188rem;
     line-height: 1.563rem;
@@ -212,7 +213,7 @@ $spacing-units-desktop: (
     font-weight: var(--heading-font-bold);
     color: var(--justice-primary-black);
     @media screen and (min-width: $justice-lg) {
-        margin-top: map-get($spacing-units-desktop, 4);
+        margin-top: map.get($spacing-units-desktop, 4);
         font-size: 1.188rem;
         line-height: 1.875rem;
     }
@@ -220,7 +221,7 @@ $spacing-units-desktop: (
 }
 
 @mixin h6 {
-    margin-top: map-get($spacing-units-mobile, 4);
+    margin-top: map.get($spacing-units-mobile, 4);
     margin-bottom: 0;
     font-size: 1.188rem;
     line-height: 1.563rem;
@@ -228,7 +229,7 @@ $spacing-units-desktop: (
     font-weight: var(--heading-font-normal);
     color: var(--justice-primary-black);
     @media screen and (min-width: $justice-lg) {
-        margin-top: map-get($spacing-units-desktop, 4);
+        margin-top: map.get($spacing-units-desktop, 4);
         font-size: 1.188rem;
         line-height: 1.875rem;
     }
@@ -310,16 +311,18 @@ $iconSizes: (
     'lg': 6rem
 );
 
-.icon {
-    @each $size, $sizeValue in $iconSizes {
-        @each $icon, $ext in $iconTypes {
-            &-#{$icon}--#{$size} {
-                display: block;
-                background-image: url(/src/assets/icons/#{$icon}.#{$ext});
-                background-repeat: no-repeat;
-                height: $sizeValue;
-                width: $sizeValue;
-                background-size: $sizeValue;
+@mixin icons() {
+    .icon {
+        @each $size, $sizeValue in $iconSizes {
+            @each $icon, $ext in $iconTypes {
+                &-#{$icon}--#{$size} {
+                    display: block;
+                    background-image: url(/src/assets/icons/#{$icon}.#{$ext});
+                    background-repeat: no-repeat;
+                    height: $sizeValue;
+                    width: $sizeValue;
+                    background-size: $sizeValue;
+                }
             }
         }
     }

--- a/public/app/frontend/webpack.config.js
+++ b/public/app/frontend/webpack.config.js
@@ -49,7 +49,12 @@ module.exports = {
             },
             {
                 test: /\.s?css$/i,
-                use: [MiniCssExtractPlugin.loader, { loader: 'css-loader', options: { url: true, sourceMap: true } }, 'postcss-loader', 'sass-loader']
+                use: [
+                    MiniCssExtractPlugin.loader,
+                    { loader: 'css-loader', options: { url: true, sourceMap: true } },
+                    'postcss-loader',
+                    { loader: "sass-loader", options: { api: "modern-compiler" } }
+                ]
             },
             {
                 test: /\.(jpg|png|svg|gif)$/,


### PR DESCRIPTION
In this PR:

Legacy sass `@import` is replaces with `@use`. `@include` statements are now name-spaced.
Reference: https://sass-lang.com/documentation/breaking-changes/import/

The icon css block has been moved, so that is is processed and transformed to css once - instead of once for each frontend component.

The sass module had been updated, along with webpack config `api: "modern-compiler"`. This fixes a legacy JS api warning.
Reference: https://sass-lang.com/documentation/breaking-changes/legacy-js-api/

