### PR TITLE
CDPT-2999 Add language metadata on pages

### DIFF
--- a/public/app/themes/justice/inc/post-meta/constants.php
+++ b/public/app/themes/justice/inc/post-meta/constants.php
@@ -20,6 +20,7 @@ class PostMetaConstants
     public $values_language =  [
         ['label' => 'English', 'value' => 'en_GB'],
         ['label' => 'Welsh', 'value' => 'cy_GB'],
+        ['label' => 'English and Welsh', 'value' => 'en_GB,cy_GB'],
     ];
 
     /**


### PR DESCRIPTION
This PR has been created so that in a following PR, legacy Welsh language pages can be excluded from spell check.

<img width="314" height="557" alt="image" src="https://github.com/user-attachments/assets/7494b172-6131-454b-8294-890b5f7e0ccd" />
