### PR TITLE
CDPT-2941 Handle h1 headings un page content.

### DIFF
--- a/public/app/frontend/style.scss
+++ b/public/app/frontend/style.scss
@@ -571,6 +571,24 @@ $iconSizes: (
         }
     }
 
+    html.rich-text-contains-h1 & {
+        h1 {
+            @include h2;
+        }
+        h2 {
+            @include h3;
+        }
+        h3 {
+            @include h4;
+        }
+        h4 {
+            @include h5;
+        }
+        h5 {
+            @include h6;
+        }
+    }
+
     @media print {
         // On print, append the URL to external links.
         .link--external::after {

--- a/public/app/themes/justice/header.php
+++ b/public/app/themes/justice/header.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html <?php language_attributes(); ?>>
+<html <?php language_attributes(); ?> class="<?php echo esc_attr(implode(' ', get_body_class())); ?>">
 <head>
     <meta charset="<?php bloginfo('charset'); ?>"/>
     <meta name="viewport" content="width=device-width"/>

--- a/public/app/themes/justice/inc/content.php
+++ b/public/app/themes/justice/inc/content.php
@@ -22,6 +22,7 @@ class Content
     public function addHooks(): void
     {
         add_filter('the_content', [$this, 'fixNationalArchiveLinks']);
+        add_filter('body_class', [$this, 'addBodyClassIfContentContainsH1'], 25);
     }
 
     /**
@@ -50,6 +51,28 @@ class Content
 
         return $content;
     }
+
+
+    /**
+     * Add a body class if the content contains an <h1> tag.
+     *
+     * This is used to add the 'rich-text-contains-h1' class to the body element,
+     * which can be used to style the rich text component differently if it contains an <h1> tag.
+     *
+     * @param array $classes The existing body classes.
+     * @return array The modified body classes.
+     */
+    public function addBodyClassIfContentContainsH1($classes)
+    {
+        if ((is_single() || is_page()) && is_main_query()) {
+            $content = get_the_content();
+            if (strpos($content, '<h1') !== false) {
+                return [...$classes, 'rich-text-contains-h1'];
+            }
+        }
+        return $classes;
+    }
+
 
     /**
      * Determine if a link is external or internal so that we can add (opens in new tab)

--- a/public/app/themes/justice/inc/core.php
+++ b/public/app/themes/justice/inc/core.php
@@ -33,6 +33,8 @@ class Core
         add_filter('pre_http_request', [$this, 'handleLoopbackRequests'], 10, 3);
         // Remove Available Tools from the admin menu.
         add_action('admin_menu', [$this, 'removeSubmenus']);
+        // Remove all body classes set by WordPress - if we need to add any, use a priority > 20.
+        add_filter('body_class', '__return_empty_array', 20);
     }
 
     /**


### PR DESCRIPTION
This PR knocks down the heading sizes if H! is in the user content.

Before: 

<img width="640" height="628" alt="image" src="https://github.com/user-attachments/assets/d96a775a-6457-474f-9e78-6f3d392da152" />

After:

<img width="1011" height="891" alt="image" src="https://github.com/user-attachments/assets/b4589d22-1df7-4e95-b39d-783d31b7089d" />
