### PR TITLE
CDPT-3092 Log http requests to unknown domains

### DIFF
--- a/public/app/mu-plugins/cluster-helper/cluster-helper.php
+++ b/public/app/mu-plugins/cluster-helper/cluster-helper.php
@@ -58,7 +58,7 @@ class ClusterHelper
      *               - If $format is invalid, it defaults to 'full'.
      * If the option does not exist or is not an array, it returns an empty array.
      */
-    public function getNginxHosts($format = 'full'): array
+    public static function getNginxHosts($format = 'full'): array
     {
         // Validate the format parameter
         if (!in_array($format, ['full', 'hosts'])) {
@@ -66,7 +66,7 @@ class ClusterHelper
         }
 
         // Get the current nginx hosts from the option
-        $nginx_hosts_string = get_option($this::OPTION_KEY, '');
+        $nginx_hosts_string = get_option(self::OPTION_KEY, '');
         $nginx_hosts = maybe_unserialize($nginx_hosts_string);
 
         // Ensure it's an array

--- a/public/app/themes/justice/functions.php
+++ b/public/app/themes/justice/functions.php
@@ -43,6 +43,7 @@ require_once 'inc/sitemap.php';
 require_once 'inc/taxonomies.php';
 require_once 'inc/theme-assets.php';
 require_once 'inc/theme.php';
+require_once 'inc/updates.php';
 require_once 'inc/utils.php';
 
 if (getenv('WP_ENV') === 'development') {

--- a/public/app/themes/justice/inc/security.php
+++ b/public/app/themes/justice/inc/security.php
@@ -24,7 +24,7 @@ class Security
     /**
      * The application host e.g. intranet.docker or intranet.justice.gov.uk
      */
-    private string $home_host;  
+    private string $home_host;
 
     /**
      * Set properties and run actions.
@@ -53,7 +53,7 @@ class Security
             array_push($this->known_hosts, $custom_s3_host);
         }
 
-        if($loopback_url = Config::get('WP_LOOPBACK')) {
+        if ($loopback_url = Config::get('WP_LOOPBACK')) {
             // Push the loopback URL host to known_hosts.
             array_push($this->known_hosts, parse_url($loopback_url, PHP_URL_HOST));
         }
@@ -219,9 +219,9 @@ class Security
 
     /**
      * Log the urls of requests to unknown hosts.
-     * 
+     *
      * This could be useful in identifying requests to malicious URLs.
-     * 
+     *
      * @param false|array|\WP_Error $response
      * @param array $parsed_args
      * @param string $url

--- a/public/app/themes/justice/inc/security.php
+++ b/public/app/themes/justice/inc/security.php
@@ -3,6 +3,7 @@
 namespace MOJ\Justice;
 
 use WP_Error;
+use Roots\WPConfig\Config;
 
 /**
  * Add a little security for WordPress
@@ -12,6 +13,18 @@ class Security
 
     private $wp_version;
     private $hashed_wp_version;
+
+    /**
+     * A list of known hosts.
+     */
+    private array $known_hosts = [
+        'api.deliciousbrains.com'
+    ];
+
+    /**
+     * The application host e.g. intranet.docker or intranet.justice.gov.uk
+     */
+    private string $home_host;  
 
     /**
      * Set properties and run actions.
@@ -24,7 +37,26 @@ class Security
         // This way a we get a unique hash per WP version but it's not reversible.
         $this->hashed_wp_version = substr(hash('sha256', $this->wp_version . AUTH_SALT), 0, 6);
 
+        $this->home_host = parse_url(get_home_url(), PHP_URL_HOST);
+
         $this->actions();
+
+        // Push the application host to known_hosts.
+        array_push($this->known_hosts, $this->home_host);
+
+        // Push the S3 bucket host to known_hosts.
+        if ($s3_bucket = env('AWS_S3_BUCKET')) {
+            array_push($this->known_hosts, $s3_bucket . ".s3.eu-west-2.amazonaws.com");
+        }
+
+        if ($custom_s3_host = env('AWS_S3_CUSTOM_HOST')) {
+            array_push($this->known_hosts, $custom_s3_host);
+        }
+
+        if($loopback_url = Config::get('WP_LOOPBACK')) {
+            // Push the loopback URL host to known_hosts.
+            array_push($this->known_hosts, parse_url($loopback_url, PHP_URL_HOST));
+        }
     }
 
     /**
@@ -61,6 +93,9 @@ class Security
         add_action('template_redirect', [$this, 'disableAuthorPages'], 1);
         // Remove the "View" link from user admin screen, since these will 404.
         add_filter('user_row_actions', [$this, 'removeViewLinkOnUsersScreen'], 100);
+
+        // Log requests to unknown hosts.
+        add_filter('pre_http_request', [$this, 'logUnknownHostRequests'], 20, 3);
     }
 
     /**
@@ -179,5 +214,26 @@ class Security
             unset($actions['view']);
         }
         return $actions;
+    }
+
+
+    /**
+     * Log the urls of requests to unknown hosts.
+     * 
+     * This could be useful in identifying requests to malicious URLs.
+     * 
+     * @param false|array|\WP_Error $response
+     * @param array $parsed_args
+     * @param string $url
+     * @return false|array|\WP_Error
+     */
+    public function logUnknownHostRequests(false|array|\WP_Error $response, array $parsed_args, string $url): false|array|\WP_Error
+    {
+        if (!in_array(parse_url($url, PHP_URL_HOST), $this->known_hosts)) {
+            // Log the request url.
+            error_log('pre_http_request url: ' . $url);
+        }
+
+        return $response;
     }
 }

--- a/public/app/themes/justice/inc/security.php
+++ b/public/app/themes/justice/inc/security.php
@@ -4,6 +4,7 @@ namespace MOJ\Justice;
 
 use WP_Error;
 use Roots\WPConfig\Config;
+use MOJ\ClusterHelper;
 
 /**
  * Add a little security for WordPress
@@ -57,6 +58,11 @@ class Security
             // Push the loopback URL host to known_hosts.
             array_push($this->known_hosts, parse_url($loopback_url, PHP_URL_HOST));
         }
+
+        // Push the Nginx hosts to known_hosts.
+        $nginx_urls = ClusterHelper::getNginxHosts('hosts');
+        $nginx_hosts = array_map(fn ($host) => parse_url($host, PHP_URL_HOST), $nginx_urls);
+        array_push($this->known_hosts, ...$nginx_hosts);
     }
 
     /**

--- a/public/app/themes/justice/inc/updates.php
+++ b/public/app/themes/justice/inc/updates.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace MOJ\Justice;
+
+/**
+ * Functions to related to updates, and disabling checks.
+ */
+class Updates
+{
+    public function __construct()
+    {
+        $this->hooks();
+    }
+
+    /**
+     * @return void
+     */
+    public function hooks(): void
+    {
+        /**
+         * Prevent http requests to api.wordpress.org to check for WP core versions.
+         * 
+         * Even though `AUTOMATIC_UPDATER_DISABLED` is set to true, we need to block
+         * requests api.wordpress.org to where WP checks for available versions.
+         * 
+         * This filter's function returns a dummy payload that will prevent an api request, 
+         * and not cause an error.
+         * 
+         * @see https://wp-kama.com/2020/disable-wp-updates-check
+         * @see https://developer.wordpress.org/reference/functions/wp_version_check/
+         */
+        add_filter(
+            'pre_site_transient_update_core',
+            fn() =>  (object) [
+                'updates' => [],
+                'version_checked' => $GLOBALS['wp_version'],
+                'last_checked' => time()
+            ]
+        );
+
+        /**
+         * Prevent http requests to api.wordpress.org to check for theme version.
+         * 
+         * This filter's function returns a dummy payload that will prevent an api request,
+         * and not cause an error.
+         * 
+         * @see https://wp-kama.com/2020/disable-wp-updates-check
+         * @see https://developer.wordpress.org/reference/functions/wp_update_themes/
+         */
+        add_filter('pre_site_transient_update_themes', static function ($value) {
+            static $theme;
+
+            $theme || $theme = wp_get_theme('justice');
+
+            return (object) [
+                'last_checked' => time(),
+                'checked' => [
+                    'justice' => $theme->get('Version')
+                ]
+            ];
+        });
+
+        /**
+         * Prevent http requests to api.wordpress.org to check for plugin versions.
+         * 
+         * This filter's function returns a dummy payload that will prevent an api request,
+         * and not cause an error.
+         * 
+         * @see https://wp-kama.com/2020/disable-wp-updates-check
+         * @see https://developer.wordpress.org/reference/functions/wp_update_plugins/
+         */
+        add_filter('pre_site_transient_update_plugins', static function ($value) {
+            static $plugins;
+            $plugins || $plugins = get_plugins();
+
+            $return_value = (object) [
+                'last_checked' => time(),
+                'checked' => []
+            ];
+
+            foreach ($plugins as $file => $p) {
+                $return_value->checked[$file] = $p['Version'];
+            }
+
+            return $return_value;
+        });
+    }
+}
+
+new Updates();

--- a/public/app/themes/justice/inc/updates.php
+++ b/public/app/themes/justice/inc/updates.php
@@ -19,13 +19,13 @@ class Updates
     {
         /**
          * Prevent http requests to api.wordpress.org to check for WP core versions.
-         * 
+         *
          * Even though `AUTOMATIC_UPDATER_DISABLED` is set to true, we need to block
          * requests api.wordpress.org to where WP checks for available versions.
-         * 
-         * This filter's function returns a dummy payload that will prevent an api request, 
+         *
+         * This filter's function returns a dummy payload that will prevent an api request,
          * and not cause an error.
-         * 
+         *
          * @see https://wp-kama.com/2020/disable-wp-updates-check
          * @see https://developer.wordpress.org/reference/functions/wp_version_check/
          */
@@ -40,10 +40,10 @@ class Updates
 
         /**
          * Prevent http requests to api.wordpress.org to check for theme version.
-         * 
+         *
          * This filter's function returns a dummy payload that will prevent an api request,
          * and not cause an error.
-         * 
+         *
          * @see https://wp-kama.com/2020/disable-wp-updates-check
          * @see https://developer.wordpress.org/reference/functions/wp_update_themes/
          */
@@ -62,10 +62,10 @@ class Updates
 
         /**
          * Prevent http requests to api.wordpress.org to check for plugin versions.
-         * 
+         *
          * This filter's function returns a dummy payload that will prevent an api request,
          * and not cause an error.
-         * 
+         *
          * @see https://wp-kama.com/2020/disable-wp-updates-check
          * @see https://developer.wordpress.org/reference/functions/wp_update_plugins/
          */


### PR DESCRIPTION
This PR ports over functionality from the Intranet

- Log http requests that connect to unknown domains.
- Don't connect to WordPress to check if core, plugins or theme is outdated.