### PR TITLE
CDPTKAN-288 Add 'Scanning for malware' UI after document upload.

### DIFF
--- a/config/env.php
+++ b/config/env.php
@@ -16,5 +16,13 @@ namespace MOJ\Justice;
 
 function env(string $key) : mixed
 {
-    return isset($_ENV[$key]) ? $_ENV[$key] : null;
+    // Get the value from the $_ENV super-global
+    $value = $_ENV[$key] ?? null;
+
+    // Convert 'true'/'false' strings to boolean values
+    if (in_array($value, ['true', 'false'], true)) {
+        $value = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    return $value;
 }

--- a/public/app/mu-plugins/av.php
+++ b/public/app/mu-plugins/av.php
@@ -35,9 +35,14 @@ class AV
     public static function init(): void
     {
         // Exit early if antivirus scanning is disabled
-        if (Config::get('CLAM_DISABLED') === 'true') {
+        if (Config::get('CLAM_DISABLED') === true) {
             return;
         }
+
+        // Let's ad an admin body-class to indicate AV is enabled
+        add_filter('admin_body_class', function ($classes) {
+            return trim($classes . ' av-enabled');
+        });
 
         // Hook into WordPress file upload process
         add_filter('wp_handle_upload_prefilter', function ($file) {
@@ -47,6 +52,8 @@ class AV
             if (!$tmp || !is_file($tmp)) {
                 return $file;
             }
+
+            sleep(10);
 
             // Scan the uploaded file with ClamAV
             $result = self::scanWithClam($tmp);

--- a/public/app/themes/justice/src/js/admin/av.js
+++ b/public/app/themes/justice/src/js/admin/av.js
@@ -1,0 +1,140 @@
+class MediaProgressWatcher {
+  /**
+   * Prime internal state for tracking upload progress elements.
+   * @returns {void}
+   */
+  constructor() {
+    this.selector = "#media-items .progress";
+    this.trackedProgress = new WeakSet();
+    this.observer = null;
+    this.started = false;
+  }
+
+  /**
+   * Begin observing the DOM for matching progress nodes.
+   * @returns {void}
+   */
+  start() {
+    // Only start if AV is enabled. Checks both the iframe parent and the current
+    // document in case this script is running inside an iframe.
+    if (
+      !window.parent?.document.body.classList.contains("av-enabled") &&
+      !document.body.classList.contains("av-enabled")
+    ) {
+      return;
+    }
+
+    if (this.started) {
+      return;
+    }
+
+    this.started = true;
+
+    this.observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        mutation.addedNodes.forEach((node) => this.visitNode(node));
+      });
+    });
+
+    this.observer.observe(document.body, { childList: true, subtree: true });
+
+    // Bind to any progress bars that already exist at start-up.
+    document
+      .querySelectorAll(this.selector)
+      .forEach((element) => this.watchProgress(element));
+  }
+
+  /**
+   * Tear down timers and observers when no longer needed.
+   * @returns {void}
+   */
+  stop() {
+    if (!this.started) {
+      return;
+    }
+
+    this.started = false;
+    if (this.observer) {
+      this.observer.disconnect();
+      this.observer = null;
+    }
+  }
+
+  /**
+   * Inspect added nodes for progress elements to track.
+   * @param {Node} node
+   * @returns {void}
+   */
+  visitNode(node) {
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+      return;
+    }
+
+    const element = node;
+    if (element.matches?.(this.selector)) {
+      this.watchProgress(element);
+    }
+
+    element
+      .querySelectorAll?.(this.selector)
+      .forEach((match) => this.watchProgress(match));
+  }
+
+  /**
+   * Parse a percentage value from the element text.
+   * @param {Element} element
+   * @returns {number|null}
+   */
+  extractPercent(element) {
+    const text = element.textContent ?? "";
+    const textMatch = text.match(/(\d+)(?=\s*%)/);
+
+    return textMatch ? parseInt(textMatch[1], 10) : null;
+  }
+
+  /**
+   * Attach mutation listeners so we can respond to updates.
+   * @param {Element} element
+   * @returns {void}
+   */
+  watchProgress(element) {
+    if (this.trackedProgress.has(element)) {
+      return;
+    }
+
+    this.trackedProgress.add(element);
+
+    const report = () => {
+      const percent = this.extractPercent(element);
+      if (percent !== null) {
+        this.handleProgress(percent, element);
+      }
+    };
+
+    report();
+
+    const progressObserver = new MutationObserver(report);
+    progressObserver.observe(element, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+  }
+
+  /**
+   * Switch to the processing state once 100% is reached.
+   * @param {number} percent
+   * @param {Element} element
+   * @returns {void}
+   */
+  handleProgress(percent, element) {
+    const percentElement = element.querySelector(".percent");
+
+    if (percentElement && percent === 100) {
+      // If we are at 100%, switch to processing state
+      percentElement.textContent = "Scanning for malware…";
+    }
+  }
+}
+
+export default MediaProgressWatcher;

--- a/public/app/themes/justice/src/js/admin/index.js
+++ b/public/app/themes/justice/src/js/admin/index.js
@@ -1,2 +1,15 @@
-import './request-errors';
-import '../../components/previous-permalinks/admin.js';
+import MediaProgressWatcher from "./av.js";
+import "./request-errors";
+import "../../components/previous-permalinks/admin.js";
+
+/**
+ * Initialise and start a MediaProgressWatcher instance.
+ * This is used to display "Scanning for malware…" once media upload reaches 100%.
+ */
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", () =>
+    new MediaProgressWatcher().start(),
+  );
+} else {
+  new MediaProgressWatcher().start();
+}


### PR DESCRIPTION
Recently we added ClamAV file scanning after an editor uploads a document.

It was found that the UI would freeze at 100% upload, while the file was being scanned in the background.

This caused an editor to click the close button (x) in the top right, before waiting for the scan to complete.

This PR improves the UI by changing the 100% status to `Scanning for malware…` while the scan is in progress. This feedback to the user communicates that they should wait for the scan to complete, and that their upload is still being processed.