### PR TITLE
Update ingress auth realm (it's invalid with new ingress class)

### DIFF
--- a/deploy/demo/ingress.tpl.yml
+++ b/deploy/demo/ingress.tpl.yml
@@ -11,7 +11,7 @@ metadata:
       ${MODSEC_CONFIG}
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: basic-auth-secret
-    nginx.ingress.kubernetes.io/auth-realm: 'Demo User | Authentication Required'
+    nginx.ingress.kubernetes.io/auth-realm: 'Demo User - Authentication Required'
     nginx.ingress.kubernetes.io/proxy-body-size: "200m"
     nginx.ingress.kubernetes.io/server-snippet: |
       location = /health {

--- a/deploy/development/ingress.tpl.yml
+++ b/deploy/development/ingress.tpl.yml
@@ -13,7 +13,7 @@ metadata:
       ${MODSEC_CONFIG}
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: basic-auth-secret
-    nginx.ingress.kubernetes.io/auth-realm: 'Development User | Authentication Required'
+    nginx.ingress.kubernetes.io/auth-realm: 'Development User - Authentication Required'
     nginx.ingress.kubernetes.io/proxy-body-size: "200m"
     nginx.ingress.kubernetes.io/server-snippet: |
       if ($host = 'justice-gov-uk-dev.apps.live.cloud-platform.service.justice.gov.uk') {

--- a/deploy/staging/ingress.tpl.yml
+++ b/deploy/staging/ingress.tpl.yml
@@ -13,7 +13,7 @@ metadata:
       ${MODSEC_CONFIG}
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: basic-auth-secret
-    nginx.ingress.kubernetes.io/auth-realm: 'Staging User | Authentication Required'
+    nginx.ingress.kubernetes.io/auth-realm: 'Staging User - Authentication Required'
     nginx.ingress.kubernetes.io/proxy-body-size: "200m"
     nginx.ingress.kubernetes.io/server-snippet: |
       location = /health {


### PR DESCRIPTION
Fixes:

```
Error from server (BadRequest): error when creating "deploy/development/ingress.yaml": admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: annotation nginx.ingress.kubernetes.io/auth-realm contains invalid value
service/nginx-service unchanged
```