### PR TITLE
Fix csp when no cdn

### DIFF
--- a/deploy/config/local/server.conf
+++ b/deploy/config/local/server.conf
@@ -22,7 +22,15 @@ upstream fpm {
 # Used in Content Security Policy settings.
 map $host $cdn_domain {
     default "";
-    justice.docker cdn.justice.docker;
+    justice.docker "";
+}
+
+# Map of the cdn build URL.
+# If $cdn_domain is set, then this appends /build/
+# Used in Content Security Policy settings.
+map $cdn_domain $cdn_build_url {
+    default "";
+    ~.+     $cdn_domain/build/;
 }
 
 # Content Security Policy (CSP) settings
@@ -58,17 +66,19 @@ map $http_cookie $csp_style_logged_in {
 map $request_uri $csp_style {
     # Default CSP for public pages
     # - self: allows styles from the same origin.
-    default "style-src 'self' $csp_style_logged_in ${cdn_domain}/build/";
+    # - $cdn_build_url: allows styles from the CDN build directory.
+    default "style-src 'self' $csp_style_logged_in $cdn_build_url";
 
     # Specific CSP for admin pages
     # - self: allows styles from the same origin.
     # - unsafe-inline: allows inline styles, e.g. the `style`s for revisionary and tree view.
-    ~^/wp/wp-admin/ "style-src 'self' 'unsafe-inline' ${cdn_domain}/build/";
-    ~^/wp/wp-login.php "style-src 'self' 'unsafe-inline' ${cdn_domain}/build/";
+    # - $cdn_build_url: allows styles from the CDN build directory.
+    ~^/wp/wp-admin/ "style-src 'self' 'unsafe-inline' $cdn_build_url";
+    ~^/wp/wp-login.php "style-src 'self' 'unsafe-inline' $cdn_build_url";
 
     # For theme assets, we allow the inline styles, set by the user agent.
     # - unsafe-inline: allows inline styles, e.g. the `style` attribute on images.
-    ~^/app/themes/justice/dist/ "style-src 'self' 'unsafe-inline' ${cdn_domain}/build/";
+    ~^/app/themes/justice/dist/ "style-src 'self' 'unsafe-inline' $cdn_build_url";
 }
 
 
@@ -89,24 +99,26 @@ map $request_uri $csp_script {
     # - self: allows scripts from the same origin.
     # - unsafe-inline: allows inline scripts, e.g. the `onclick` attribute on header menu items.
     # - unsafe-eval: allows the use of eval() in scripts, which is often used in development tools.
+    # - $cdn_build_url: allows scripts from the CDN build directory.
     # - googletagmanager.com: allows scripts from Google Tag Manager.
     # - Important, only use 'unsafe-eval' for the public pages during dev!
-    default "script-src 'self' 'unsafe-eval' https://www.googletagmanager.com/ $csp_script_logged_in ${cdn_domain}/build/";
+    default "script-src 'self' 'unsafe-eval' https://www.googletagmanager.com/ $csp_script_logged_in $cdn_build_url";
 
     # Specific CSP for admin pages
     # - self: allows scripts from the same origin.
     # - unsafe-inline: allows inline scripts, potentially used by plugins or themes.
-    ~^/wp/wp-login.php "script-src 'self' 'unsafe-inline' 'unsafe-eval' ${cdn_domain}/build/";
+    # - $cdn_build_url: allows scripts from the CDN build directory.
+    ~^/wp/wp-login.php "script-src 'self' 'unsafe-inline' 'unsafe-eval' $cdn_build_url";
     # - unsafe-eval: necessary for admin scripts e.g. for Media Library.
-    ~^/wp/wp-admin/ "script-src 'self' 'unsafe-inline' 'unsafe-eval' ${cdn_domain}/build/";
+    ~^/wp/wp-admin/ "script-src 'self' 'unsafe-inline' 'unsafe-eval' $cdn_build_url";
 }
 
 map $request_uri $csp_worker {
     # Default CSP for public pages
     # - self: allow workers hosted on the same origin.
-    # - ${cdn_domain}/build/: allow workers from the CDN build directory.
+    # - $cdn_build_url: allow workers from the CDN build directory.
     # - blob: allow workers where the source is a blob, e.g. for Sentry Browser Tracing.
-    default "worker-src 'self' ${cdn_domain}/build/ blob:";
+    default "worker-src 'self' $cdn_build_url blob:";
 }
 
 server {

--- a/deploy/config/server.conf
+++ b/deploy/config/server.conf
@@ -104,7 +104,7 @@ map $request_uri $csp_script {
     # Specific CSP for admin pages
     # - self: allows scripts from the same origin.
     # - unsafe-inline: allows inline scripts, potentially used by plugins or themes.
-    # - $cdn_build_url: allows styles from the CDN build directory.
+    # - $cdn_build_url: allows scripts from the CDN build directory.
     ~^/wp/wp-login.php "script-src 'self' 'unsafe-inline' $cdn_build_url";
     # - unsafe-eval: necessary for admin scripts e.g. for Media Library.
     ~^/wp/wp-admin/ "script-src 'self' 'unsafe-inline' $cdn_build_url 'unsafe-eval'";

--- a/deploy/config/server.conf
+++ b/deploy/config/server.conf
@@ -23,6 +23,13 @@ map $host $cdn_domain {
     www.justice.gov.uk "";
 }
 
+# Map of the cdn build URL.
+# If $cdn_domain is set, then this appends /build/
+# Used in Content Security Policy settings.
+map $cdn_domain $cdn_build_url {
+    default "";
+    ~.+     $cdn_domain/build/;
+}
 
 # Content Security Policy (CSP) settings
 # - The CSP is split into four parts: one for styles, images, scripts and web workers.
@@ -57,16 +64,16 @@ map $http_cookie $csp_style_logged_in {
 map $request_uri $csp_style {
     # Default CSP for public pages
     # - self: allows styles from the same origin.
-    # - ${cdn_domain}/build/: allows styles from the CDN build directory.
-    default "style-src 'self' ${cdn_domain}/build/ $csp_style_logged_in";
+    # - $cdn_build_url: allows styles from the CDN build directory.
+    default "style-src 'self' $cdn_build_url $csp_style_logged_in";
 
     # Specific CSP for admin pages
     # - self: allows styles from the same origin.
     # - unsafe-inline: allows inline styles, e.g. the `style`s for revisionary and tree view.
-    # - ${cdn_domain}/build/: allows styles from the CDN build directory.
-    ~^/wp/wp-login.php "style-src 'self' 'unsafe-inline' ${cdn_domain}/build/";
+    # - $cdn_build_url: allows styles from the CDN build directory.
+    ~^/wp/wp-login.php "style-src 'self' 'unsafe-inline' $cdn_build_url";
     # - unsafe-eval: necessary for admin scripts e.g. for Media Library.
-    ~^/wp/wp-admin/ "style-src 'self' 'unsafe-inline' ${cdn_domain}/build/ 'unsafe-eval'";
+    ~^/wp/wp-admin/ "style-src 'self' 'unsafe-inline' $cdn_build_url 'unsafe-eval'";
 
     # For theme assets, we allow the inline styles, set by the user agent.
     # - unsafe-inline: allows inline styles, e.g. the `style` attribute on images.
@@ -90,17 +97,17 @@ map $request_uri $csp_script {
     # Default CSP for public pages
     # - self: allows scripts from the same origin.
     # - unsafe-inline: allows inline scripts, e.g. the `onclick` attribute on header menu items.
-    # - ${cdn_domain}/build/: allows styles from the CDN build directory.
+    # - $cdn_build_url: allows scripts from the CDN build directory.
     # - googletagmanager.com: allows scripts from Google Tag Manager.
-    default "script-src 'self' ${cdn_domain}/build/ https://www.googletagmanager.com/ $csp_script_logged_in";
+    default "script-src 'self' $cdn_build_url https://www.googletagmanager.com/ $csp_script_logged_in";
 
     # Specific CSP for admin pages
     # - self: allows scripts from the same origin.
     # - unsafe-inline: allows inline scripts, potentially used by plugins or themes.
-    # - ${cdn_domain}/build/: allows styles from the CDN build directory.
-    ~^/wp/wp-login.php "script-src 'self' 'unsafe-inline' ${cdn_domain}/build/";
+    # - $cdn_build_url: allows styles from the CDN build directory.
+    ~^/wp/wp-login.php "script-src 'self' 'unsafe-inline' $cdn_build_url";
     # - unsafe-eval: necessary for admin scripts e.g. for Media Library.
-    ~^/wp/wp-admin/ "script-src 'self' 'unsafe-inline' ${cdn_domain}/build/ 'unsafe-eval'";
+    ~^/wp/wp-admin/ "script-src 'self' 'unsafe-inline' $cdn_build_url 'unsafe-eval'";
 }
 
 map $request_uri $csp_worker {


### PR DESCRIPTION
Fixes:

> `wp-sentry-browser.tr…min.js?ver=8.10.0:2 The source list for the Content Security Policy directive 'style-src' contains an invalid source: '/build/'. It will be ignored.`